### PR TITLE
fix(install): Check write permissions for install directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,25 +27,32 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Determine install location
 if [[ -w "/usr/local/bin" ]]; then
-  INSTALL_DIR="/usr/local/bin"
-elif [[ -d "$HOME/.local/bin" ]]; then
-  INSTALL_DIR="$HOME/.local/bin"
+    INSTALL_DIR="/usr/local/bin"
+elif [[ -d "$HOME/.local/bin" && -w "$HOME/.local/bin" ]]; then
+    INSTALL_DIR="$HOME/.local/bin"
 else
-  INSTALL_DIR="$HOME/.local/bin"
-  mkdir -p "$INSTALL_DIR"
+    INSTALL_DIR="$HOME/.local/bin"
+    mkdir -p "$INSTALL_DIR"
 fi
 
 echo -e "${BLUE}ℹ️  Install directory: $INSTALL_DIR${NC}"
 echo ""
 
+if [[ ! -w "$INSTALL_DIR" ]]; then
+    echo -e "${RED}❌ No write permission to $INSTALL_DIR${NC}"
+    echo -e "${YELLOW}Fix ownership or permissions, e.g.:${NC}"
+    echo "  sudo chown -R $USER:$USER $INSTALL_DIR"
+    exit 1
+fi
+
 # Check if already installed
 if [[ -f "$INSTALL_DIR/gga" ]]; then
-  echo -e "${YELLOW}⚠️  gga is already installed${NC}"
-  read -p "Reinstall? (y/N): " confirm
-  if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
-    echo "Aborted."
-    exit 0
-  fi
+    echo -e "${YELLOW}⚠️  gga is already installed${NC}"
+    read -p "Reinstall? (y/N): " confirm
+    if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
 fi
 
 # Create lib directory


### PR DESCRIPTION
I got and issue when running the `./install.sh` script, so I add an additional check for it, with a short solution echo.

Add an explicit write-permission check for the selected install directory. This prevents cryptic `cp: Permission denied` errors and provides clear, actionable guidance to fix ownership or permissions before installation.

Error:
```txt
cp: cannot create regular file '/home/$USER/.local/bin/gga': Permission denied
```

Solution:
Fix ownership permissions:
```txt
sudo chown -R $USER:$USER /home/kyonax/.local/bin
```

Modified-by: Cristian D. Moreno - Kyonax <kyonax.corp@gmail.com>