### PR TITLE
feat!: switch from pre-commit to commit-msg hook for commit message access

### DIFF
--- a/bin/gga
+++ b/bin/gga
@@ -731,6 +731,9 @@ cmd_run() {
     echo ""
     echo "Fix the violations listed above before committing."
     echo ""
+    echo "⚠️  RECOVERY TIP: Do NOT use destructive git commands (git reset, git read-tree, etc.)"
+    echo "   Simply fix the issues and run 'git commit' again. Your staged changes are preserved."
+    echo ""
     exit 1
   else
     log_warning "Could not determine review status"
@@ -739,6 +742,9 @@ cmd_run() {
       echo ""
       echo "The AI response must start with 'STATUS: PASSED' or 'STATUS: FAILED'"
       echo "Set STRICT_MODE=false in config to allow ambiguous responses"
+      echo ""
+      echo "⚠️  RECOVERY TIP: Do NOT use destructive git commands (git reset, git read-tree, etc.)"
+      echo "   Simply fix the issues and run 'git commit' again. Your staged changes are preserved."
       echo ""
       exit 1
     else


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE

This PR switches GGA from using the `pre-commit` hook to the `commit-msg` hook.

### Migration Required

Existing users must run:
```bash
gga uninstall   # Remove old pre-commit hook
gga install     # Install new commit-msg hook
```

If you try to install without uninstalling first, GGA will detect the legacy hook and prompt you:
```
⚠️  Found GGA in pre-commit hook (legacy location)
ℹ️  GGA now uses commit-msg hook for better commit message access
ℹ️  Run 'gga uninstall' first to remove the old hook, then 'gga install' again
```

---

## Summary

Switches GGA from `pre-commit` to `commit-msg` hook, enabling full access to the commit message during AI review.

### Why This Change?

The `pre-commit` hook runs **before** git writes the commit message, so it cannot access the message content. The `commit-msg` hook runs **after** the message is written but **before** the commit is finalized, giving us:

- ✅ Full access to staged files and diff (same as before)
- ✅ Full access to the complete commit message (NEW!)
- ✅ Ability to block commits (same as before)

### New Capability: `INCLUDE_COMMIT_MSG`

```bash
# In .gga config
INCLUDE_COMMIT_MSG="true"
```

When enabled, the commit message is sent to the AI reviewer, enabling:
- Validation of conventional commit format
- Checking commit message references to issues/specs
- Ensuring commit message matches the staged changes
- Three-phase AI review including commit message validation

### Example Output

```
ℹ️  Provider: claude
ℹ️  Rules file: AGENTS.md  
ℹ️  File patterns: *.rs,*.toml
ℹ️  Include commit message: enabled
ℹ️  Cache: enabled

Files to review:
  - src/auth.rs

ℹ️  Sending to claude for review...

STATUS: PASSED

The commit message follows the conventional commits specification:
- Type: feat (valid)
- Subject: add login endpoint
- Footer: Closes #123 (valid issue reference)

✅ CODE REVIEW PASSED
```

### Recovery Warning for AI Agents

When a review fails, GGA now displays a warning to prevent destructive recovery commands:

```
❌ CODE REVIEW FAILED

Fix the violations listed above before committing.

⚠️  RECOVERY TIP: Do NOT use destructive git commands (git reset, git read-tree, etc.)
   Simply fix the issues and run 'git commit' again. Your staged changes are preserved.
```

This addresses reports of AI coding agents using destructive commands like `git reset HEAD~1` or `git read-tree HEAD` when reviews fail, which corrupts the working directory. GGA does NOT modify the git index - staged changes are always preserved after a failed review.

### Technical Changes

- `cmd_install` creates `commit-msg` hook instead of `pre-commit`
- `cmd_uninstall` handles both legacy `pre-commit` and new `commit-msg` hooks
- `cmd_run` accepts commit message file path as first argument
- Uses `git rev-parse --git-path hooks` for worktree compatibility
- Added `GGA_MARKER_START/END` for clean hook section management
- Inserts GGA before `exit 0` in existing hooks (doesn't break other hooks)
- Added recovery warning footer on review failure to prevent destructive git commands