### PR TITLE
feat: add timeout and progress feedback for provider execution

### DIFF
--- a/bin/gga
+++ b/bin/gga
@@ -50,6 +50,7 @@ NC='\033[0m' # No Color
 DEFAULT_FILE_PATTERNS="*"
 DEFAULT_RULES_FILE="AGENTS.md"
 DEFAULT_STRICT_MODE="true"
+DEFAULT_TIMEOUT="300"  # 5 minutes - generous default for large reviews
 
 # ============================================================================
 # Helper Functions
@@ -101,6 +102,7 @@ print_help() {
   echo "                     Example: *.test.ts,*.spec.ts,*.d.ts"
   echo "  RULES_FILE         File containing review rules (default: AGENTS.md)"
   echo "  STRICT_MODE        Fail on ambiguous AI response (default: true)"
+  echo "  TIMEOUT            Max seconds to wait for AI response (default: 300)"
   echo ""
   echo -e "${BOLD}EXAMPLES:${NC}"
   echo "  gga init               # Create sample config"
@@ -113,6 +115,7 @@ print_help() {
   echo ""
   echo -e "${BOLD}ENVIRONMENT VARIABLES:${NC}"
   echo "  GGA_PROVIDER      Override provider from config"
+  echo "  GGA_TIMEOUT       Override timeout from config (seconds)"
   echo ""
 }
 
@@ -147,6 +150,7 @@ load_config() {
   EXCLUDE_PATTERNS=""
   RULES_FILE="$DEFAULT_RULES_FILE"
   STRICT_MODE="$DEFAULT_STRICT_MODE"
+  TIMEOUT="$DEFAULT_TIMEOUT"
 
   # Load global config first
   GLOBAL_CONFIG="$HOME/.config/gga/config"
@@ -165,6 +169,9 @@ load_config() {
   # Environment variable overrides everything
   if [[ -n "$GGA_PROVIDER" ]]; then
     PROVIDER="$GGA_PROVIDER"
+  fi
+  if [[ -n "${GGA_TIMEOUT:-}" ]]; then
+    TIMEOUT="$GGA_TIMEOUT"
   fi
 }
 
@@ -211,6 +218,7 @@ cmd_config() {
   fi
   echo -e "  RULES_FILE:        ${CYAN}$RULES_FILE${NC}"
   echo -e "  STRICT_MODE:       ${CYAN}$STRICT_MODE${NC}"
+  echo -e "  TIMEOUT:           ${CYAN}${TIMEOUT}s${NC}"
   echo ""
 
   # Check if rules file exists
@@ -276,6 +284,11 @@ RULES_FILE="AGENTS.md"
 # Strict mode: fail if AI response is ambiguous
 # Default: true
 STRICT_MODE="true"
+
+# Timeout in seconds for AI provider response
+# Default: 300 (5 minutes)
+# Increase for large changesets or slow connections
+TIMEOUT="300"
 EOF
 
   log_success "Created config file: $PROJECT_CONFIG"
@@ -729,15 +742,39 @@ cmd_run() {
   fi
   PROMPT=$(build_prompt "$RULES" "$files_to_review" "$use_staged" "$commit_msg")
 
-  # Execute review
-  log_info "Sending to $PROVIDER for review..."
+  # Execute review with timeout and progress feedback
+  log_info "Sending to $PROVIDER for review (timeout: ${TIMEOUT}s)..."
   echo ""
 
-  RESULT=$(execute_provider "$PROVIDER" "$PROMPT")
+  # Temporarily disable set -e to capture exit status properly
+  # (bash 3.2 on macOS can exit on non-zero in command substitution)
+  set +e
+  RESULT=$(execute_provider_with_timeout "$PROVIDER" "$PROMPT" "$TIMEOUT")
   EXEC_STATUS=$?
+  set -e
+
+  if [[ $EXEC_STATUS -eq 124 ]]; then
+    log_error "Provider timed out after ${TIMEOUT}s"
+    echo ""
+    echo "The AI provider did not respond in time. This can happen with:"
+    echo "  - Very large changesets (many files)"
+    echo "  - Slow network or API rate limiting"
+    echo ""
+    echo "Try: Increase TIMEOUT in .gga config, or review fewer files."
+    echo ""
+    if [[ "$STRICT_MODE" == "true" ]]; then
+      exit 1
+    fi
+    exit 0
+  fi
 
   if [[ $EXEC_STATUS -ne 0 ]]; then
-    log_error "Provider execution failed"
+    log_error "Provider execution failed (exit code: $EXEC_STATUS)"
+    if [[ -n "$RESULT" ]]; then
+      echo ""
+      echo "$RESULT"
+      echo ""
+    fi
     if [[ "$STRICT_MODE" == "true" ]]; then
       exit 1
     fi

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -517,3 +517,187 @@ get_provider_info() {
       ;;
   esac
 }
+
+# ============================================================================
+# Timeout Wrapper with Progress Feedback
+# ============================================================================
+
+# Execute a command with timeout and progress feedback
+# Usage: execute_with_timeout <timeout_seconds> <provider_name> <command...>
+# Returns: 0 on success, 124 on timeout, other on command failure
+execute_with_timeout() {
+  local timeout_seconds="$1"
+  local provider_name="$2"
+  shift 2
+
+  local output_file
+  output_file=$(mktemp "${TMPDIR:-/tmp}/gga_timeout_out.XXXXXX")
+  local exit_code_file
+  exit_code_file=$(mktemp "${TMPDIR:-/tmp}/gga_timeout_ec.XXXXXX")
+
+  # Determine if we can use fancy spinner (TTY mode)
+  local use_spinner=false
+  if [[ -t 2 ]] && [[ -z "${CI:-}" ]] && [[ -z "${GGA_NO_SPINNER:-}" ]]; then
+    use_spinner=true
+  fi
+
+  # Show initial status
+  if [[ "$use_spinner" == "true" ]]; then
+    printf "  Waiting for %s (timeout: %ds, Ctrl+C to cancel)...\n" "$provider_name" "$timeout_seconds" >&2
+  else
+    echo "  Waiting for $provider_name response (timeout: ${timeout_seconds}s)..." >&2
+  fi
+
+  # Run command in background and capture output (stdout and stderr combined)
+  (
+    "$@" > "$output_file" 2>&1
+    echo $? > "$exit_code_file"
+  ) &
+  local cmd_pid=$!
+
+  # Spinner characters and timing
+  local spin_chars='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
+  local spin_idx=0
+  local start_time=$SECONDS
+  local last_print=0
+
+  # Wait for command with timeout, showing progress
+  while kill -0 "$cmd_pid" 2>/dev/null; do
+    local elapsed=$((SECONDS - start_time))
+
+    if [[ $elapsed -ge $timeout_seconds ]]; then
+      # Timeout reached - kill the process tree
+      kill -TERM "$cmd_pid" 2>/dev/null || true
+      sleep 0.5
+      kill -KILL "$cmd_pid" 2>/dev/null || true
+      wait "$cmd_pid" 2>/dev/null || true
+
+      # Clear spinner line if in TTY mode
+      [[ "$use_spinner" == "true" ]] && printf "\r\033[K" >&2
+
+      # Output timeout error
+      echo "" >&2
+      echo "TIMEOUT: Provider did not respond within ${timeout_seconds} seconds." >&2
+      echo "" >&2
+      echo "Possible causes:" >&2
+      echo "  - Large number of files being reviewed" >&2
+      echo "  - Slow network connection" >&2
+      echo "  - Provider API issues or rate limiting" >&2
+      echo "" >&2
+      echo "Solutions:" >&2
+      echo "  - Increase TIMEOUT in .gga config (current: ${timeout_seconds}s)" >&2
+      echo "  - Review fewer files at once" >&2
+      echo "  - Check provider status/logs" >&2
+
+      rm -f "$output_file" "$exit_code_file"
+      return 124
+    fi
+
+    # Update progress display
+    if [[ "$use_spinner" == "true" ]]; then
+      local char="${spin_chars:spin_idx:1}"
+      spin_idx=$(( (spin_idx + 1) % ${#spin_chars} ))
+      printf "\r\033[K  \033[0;36m%s\033[0m Waiting for %s (%ds)..." "$char" "$provider_name" "$elapsed" >&2
+      sleep 0.1
+    else
+      # Non-TTY: print update every 30 seconds
+      if [[ $elapsed -ge $((last_print + 30)) ]]; then
+        echo "  ... still waiting (${elapsed}s elapsed)" >&2
+        last_print=$elapsed
+      fi
+      sleep 1
+    fi
+  done
+
+  # Command finished - get exit code
+  wait "$cmd_pid" 2>/dev/null || true
+
+  local exit_code
+  if [[ -f "$exit_code_file" ]]; then
+    exit_code=$(cat "$exit_code_file")
+  else
+    exit_code=1
+  fi
+
+  # Trace mode: show internal state
+  if [[ -n "${GGA_TRACE:-}" ]]; then
+    echo "[TRACE] exit_code=$exit_code" >&2
+    echo "[TRACE] output_file=$output_file size=$(wc -c < "$output_file" 2>/dev/null || echo 0)" >&2
+  fi
+
+  # Output the result (stdout + stderr combined)
+  if [[ -f "$output_file" ]] && [[ -s "$output_file" ]]; then
+    cat "$output_file"
+  elif [[ "${exit_code:-1}" -ne 0 ]]; then
+    echo "(provider returned no output)"
+  fi
+
+  rm -f "$output_file" "$exit_code_file"
+  return "${exit_code:-1}"
+}
+
+# ============================================================================
+# Provider Execution with Timeout
+# ============================================================================
+
+# Execute provider with timeout and progress feedback
+# Usage: execute_provider_with_timeout <provider> <prompt> <timeout>
+execute_provider_with_timeout() {
+  local provider="$1"
+  local prompt="$2"
+  local timeout="${3:-300}"
+  local base_provider="${provider%%:*}"
+
+  case "$base_provider" in
+    claude)
+      execute_with_timeout "$timeout" "Claude" bash -c "printf '%s' \"\$1\" | claude --print 2>&1" -- "$prompt"
+      ;;
+    gemini)
+      execute_with_timeout "$timeout" "Gemini" gemini -p "$prompt"
+      ;;
+    codex)
+      execute_with_timeout "$timeout" "Codex" codex exec "$prompt"
+      ;;
+    opencode)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" ]]; then
+        model=""
+      fi
+      if [[ -n "$model" ]]; then
+        execute_with_timeout "$timeout" "OpenCode" opencode run --model "$model" "$prompt"
+      else
+        execute_with_timeout "$timeout" "OpenCode" opencode run "$prompt"
+      fi
+      ;;
+    ollama)
+      local model="${provider#*:}"
+      local host="${OLLAMA_HOST:-http://localhost:11434}"
+
+      if ! validate_ollama_host "$host"; then
+        echo "Error: Invalid OLLAMA_HOST format. Expected: http(s)://hostname(:port)" >&2
+        return 1
+      fi
+
+      execute_with_timeout "$timeout" "Ollama ($model)" execute_ollama "$model" "$prompt"
+      ;;
+    lmstudio)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" ]]; then
+        model=""
+      fi
+      local host="${LMSTUDIO_HOST:-http://localhost:1234/v1}"
+
+      if ! validate_lmstudio_host "$host"; then
+        echo "Error: Invalid LMSTUDIO_HOST format. Expected: http(s)://hostname(:port)(/v1)" >&2
+        return 1
+      fi
+
+      execute_with_timeout "$timeout" "LM Studio" execute_lmstudio "$model" "$prompt"
+      ;;
+    *)
+      # Generic fallback: wrap execute_provider with timeout
+      # This ensures new providers added later still get timeout support
+      execute_with_timeout "$timeout" "$base_provider" execute_provider "$provider" "$prompt"
+      ;;
+  esac
+}

--- a/spec/unit/timeout_spec.sh
+++ b/spec/unit/timeout_spec.sh
@@ -1,0 +1,211 @@
+# shellcheck shell=bash
+
+# ============================================================================
+# Tests for execute_with_timeout() and execute_provider_with_timeout()
+# ============================================================================
+# TDD: Tests written BEFORE implementation.
+# Based on the design from PR #20 by @ramarivera, with fixes applied.
+# ============================================================================
+
+Describe 'execute_with_timeout()'
+  Include "$LIB_DIR/providers.sh"
+
+  # Force non-TTY mode for consistent testing
+  setup() {
+    export CI=true
+    export GGA_NO_SPINNER=1
+  }
+  Before 'setup'
+
+  cleanup() {
+    unset CI
+    unset GGA_NO_SPINNER
+    unset GGA_TRACE
+  }
+  After 'cleanup'
+
+  Describe 'successful command execution'
+    It 'returns exit code 0 for successful command'
+      When call execute_with_timeout 5 "TestProvider" echo "hello"
+      The status should eq 0
+      The output should include "hello"
+      The stderr should include "Waiting for TestProvider"
+    End
+
+    It 'captures multi-line output'
+      When call execute_with_timeout 5 "TestProvider" bash -c 'echo "Line 1"; echo "Line 2"; echo "Line 3"'
+      The status should eq 0
+      The output should include "Line 1"
+      The output should include "Line 2"
+      The output should include "Line 3"
+      The stderr should be present
+    End
+  End
+
+  Describe 'failed command execution'
+    It 'returns non-zero exit code for failed command'
+      When call execute_with_timeout 5 "TestProvider" bash -c "exit 42"
+      The status should eq 42
+      The output should include "(provider returned no output)"
+      The stderr should be present
+    End
+
+    It 'captures stderr from failing command'
+      When call execute_with_timeout 5 "TestProvider" bash -c "echo 'error message' >&2; exit 1"
+      The status should eq 1
+      # stdout+stderr are combined in output file
+      The output should include "error message"
+      The stderr should be present
+    End
+
+    It 'returns exit code 1 for false command'
+      When call execute_with_timeout 5 "TestProvider" false
+      The status should eq 1
+      The output should include "(provider returned no output)"
+      The stderr should be present
+    End
+  End
+
+  Describe 'timeout behavior'
+    It 'returns exit code 124 when command times out'
+      When call execute_with_timeout 1 "TestProvider" sleep 10
+      The status should eq 124
+      The stderr should include "TIMEOUT"
+    End
+
+    It 'includes timeout duration in error message'
+      When call execute_with_timeout 2 "SlowProvider" sleep 10
+      The status should eq 124
+      The stderr should include "2 seconds"
+    End
+
+    It 'suggests increasing TIMEOUT in error message'
+      When call execute_with_timeout 1 "TestProvider" sleep 10
+      The status should eq 124
+      The stderr should include "Increase TIMEOUT"
+    End
+  End
+
+  Describe 'progress feedback in non-TTY mode'
+    It 'shows waiting message on stderr'
+      When call execute_with_timeout 5 "TestProvider" echo "done"
+      The status should eq 0
+      The stderr should include "Waiting for TestProvider"
+      The output should include "done"
+    End
+
+    It 'includes timeout in waiting message'
+      When call execute_with_timeout 10 "TestProvider" echo "done"
+      The status should eq 0
+      The stderr should include "10s"
+      The output should include "done"
+    End
+  End
+
+  Describe 'trace mode'
+    setup_trace() {
+      export CI=true
+      export GGA_NO_SPINNER=1
+      export GGA_TRACE=1
+    }
+    Before 'setup_trace'
+
+    It 'shows trace output when GGA_TRACE is set'
+      When call execute_with_timeout 5 "TestProvider" echo "test"
+      The status should eq 0
+      The stderr should include "[TRACE]"
+      The output should include "test"
+    End
+
+    It 'shows exit code in trace'
+      When call execute_with_timeout 5 "TestProvider" bash -c "exit 7"
+      The status should eq 7
+      The stderr should include "exit_code=7"
+      The output should include "(provider returned no output)"
+    End
+  End
+End
+
+Describe 'execute_provider_with_timeout()'
+  Include "$LIB_DIR/providers.sh"
+
+  setup() {
+    export CI=true
+    export GGA_NO_SPINNER=1
+  }
+  Before 'setup'
+
+  cleanup() {
+    unset CI
+    unset GGA_NO_SPINNER
+    unset OLLAMA_HOST
+    unset LMSTUDIO_HOST
+  }
+  After 'cleanup'
+
+  Describe 'generic fallback for unknown providers'
+    It 'uses execute_provider as fallback instead of failing'
+      # Mock execute_provider for the unknown provider
+      execute_provider() {
+        echo "FALLBACK_CALLED:$1"
+      }
+
+      When call execute_provider_with_timeout "some-new-provider" "test" 5
+      The status should eq 0
+      The output should include "FALLBACK_CALLED:some-new-provider"
+      The stderr should be present
+    End
+  End
+
+  Describe 'ollama host validation'
+    It 'fails with invalid OLLAMA_HOST before attempting execution'
+      OLLAMA_HOST="invalid://bad"
+
+      When call execute_provider_with_timeout "ollama:llama3" "test" 5
+      The status should be failure
+      The stderr should include "Invalid OLLAMA_HOST"
+    End
+  End
+
+  Describe 'lmstudio host validation'
+    It 'fails with invalid LMSTUDIO_HOST before attempting execution'
+      LMSTUDIO_HOST="invalid://bad"
+
+      When call execute_provider_with_timeout "lmstudio" "test" 5
+      The status should be failure
+      The stderr should include "Invalid LMSTUDIO_HOST"
+    End
+  End
+
+  Describe 'timeout parameter passing'
+    It 'respects timeout parameter by timing out slow commands'
+      When call execute_with_timeout 1 "TestProvider" sleep 10
+      The status should eq 124
+      The stderr should include "TIMEOUT"
+    End
+  End
+End
+
+Describe 'provider base extraction in timeout context'
+  Include "$LIB_DIR/providers.sh"
+
+  helper_get_base_provider() {
+    local provider="$1"
+    echo "${provider%%:*}"
+  }
+
+  It 'extracts base provider from simple provider'
+    When call helper_get_base_provider "claude"
+    The output should eq "claude"
+  End
+
+  It 'extracts base provider from ollama:model'
+    When call helper_get_base_provider "ollama:llama3.2"
+    The output should eq "ollama"
+  End
+
+  It 'extracts base provider from lmstudio:model'
+    When call helper_get_base_provider "lmstudio:qwen"
+    The output should eq "lmstudio"
+  End
+End


### PR DESCRIPTION
## Summary

- Adds configurable timeout (default 300s) with visual spinner/progress indicator for AI provider calls
- Returns exit code 124 on timeout with helpful error messages and troubleshooting suggestions
- Includes generic provider fallback so future providers automatically get timeout support

## What Changed

### `lib/providers.sh`
- **`execute_with_timeout()`**: Generic timeout wrapper with TTY-aware spinner (fancy Unicode spinner for terminals, periodic text updates for CI/pipes)
- **`execute_provider_with_timeout()`**: Routes each known provider (claude, gemini, codex, opencode, ollama, lmstudio) through the timeout wrapper, with a `*) fallback` case that wraps `execute_provider` for unknown/future providers

### `bin/gga`
- **TIMEOUT config**: New `TIMEOUT` setting in `.gga` config (default: 300s)
- **GGA_TIMEOUT env var**: Override timeout via environment variable
- **Timeout error handling**: Exit code 124 triggers user-friendly error with suggestions
- **Enhanced error output**: Failed provider calls now show the provider's error output
- Updated `cmd_config`, `cmd_init`, `print_help` to document the new setting

### `spec/unit/timeout_spec.sh`
- **19 new ShellSpec tests** covering: successful execution, failures, timeout behavior (exit 124), progress feedback, trace mode, provider routing, host validation, generic fallback
- All **132 tests pass** (113 existing + 19 new), 0 failures

## Credits

Re-implemented with TDD based on the approach from PR #20 by @ramarivera. Key improvements:
- Generic `*) fallback` case instead of failing on unknown providers
- CI/non-TTY mode support (`GGA_NO_SPINNER`, `CI` env vars)
- Comprehensive test coverage with ShellSpec
- Trace mode support (`GGA_TRACE`)