### PR TITLE
feat: add full Windows PowerShell support

### DIFF
--- a/bin/gga.ps1
+++ b/bin/gga.ps1
@@ -1,0 +1,837 @@
+# ============================================================================
+# Gentleman Guardian Angel - PowerShell CLI
+# ============================================================================
+# Provider-agnostic code review using AI
+# ============================================================================
+
+param(
+    [Parameter(Position = 0)]
+    [string]$Command = "",
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RemainingArgs = @()
+)
+
+$ErrorActionPreference = "Stop"
+
+# Parse command and arguments
+$allArgs = @($Command) + @($RemainingArgs)
+$allArgs = @($allArgs | Where-Object { $_ -ne "" -and $_ -ne $null })
+$cmd = if ($allArgs.Count -gt 0) { $allArgs[0] } else { "" }
+
+$VERSION = "2.7.0"
+$ScriptDir = $PSScriptRoot
+if (-not $ScriptDir) {
+    $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+}
+
+# Determine lib directory - check multiple locations
+$UserHome = [System.Environment]::GetFolderPath('UserProfile')
+$InstalledLibDir = Join-Path $UserHome ".local\share\gga\lib"
+$DevLibDir = Join-Path $ScriptDir "..\lib"
+
+if (Test-Path $InstalledLibDir) {
+    $LibDir = $InstalledLibDir
+} else {
+    $LibDir = $DevLibDir
+}
+
+. "$LibDir\providers.ps1"
+. "$LibDir\cache.ps1"
+. "$LibDir\pr_mode.ps1"
+
+$script:PROVIDER = ""
+$script:FILE_PATTERNS = "*"
+$script:EXCLUDE_PATTERNS = ""
+$script:RULES_FILE = "AGENTS.md"
+$script:STRICT_MODE = $true
+$script:TIMEOUT = 300
+$script:PR_BASE_BRANCH = ""
+
+function Write-Color {
+    param(
+        [string]$Message, 
+        [string]$Color = "White"
+    )
+    $ColorMap = @{
+        "RED" = "Red"
+        "GREEN" = "Green"
+        "YELLOW" = "Yellow"
+        "BLUE" = "Blue"
+        "CYAN" = "Cyan"
+        "BOLD" = "White"
+    }
+    $fg = if ($ColorMap.ContainsKey($Color)) { $ColorMap[$Color] } else { $Color }
+    Write-Host $Message -ForegroundColor $fg
+}
+
+function Write-Banner {
+    Write-Color -Message "" -Color "Cyan"
+    Write-Color -Message "============================================================" -Color "Cyan"
+    Write-Color -Message "  Gentleman Guardian Angel v$VERSION" -Color "Cyan"
+    Write-Color -Message "  Provider-agnostic code review using AI" -Color "Cyan"
+    Write-Color -Message "============================================================" -Color "Cyan"
+    Write-Color -Message "" -Color "Cyan"
+}
+
+function Get-Help {
+    Write-Banner
+    Write-Color -Message "USAGE:" -Color "White"
+    Write-Host "  gga <command> [options]"
+    Write-Host ""
+    Write-Color -Message "COMMANDS:" -Color "White"
+    Write-Host "  run [--no-cache]  Run code review on staged files"
+    Write-Host "  install           Install git pre-commit hook (default)"
+    Write-Host "  install --commit-msg"
+    Write-Host "                    Install git commit-msg hook"
+    Write-Host "  uninstall         Remove git hooks from current repo"
+    Write-Host "  config            Show current configuration"
+    Write-Host "  init              Create a sample .gga config file"
+    Write-Host "  cache clear       Clear cache for current project"
+    Write-Host "  cache clear-all   Clear all cached data"
+    Write-Host "  cache status      Show cache status"
+    Write-Host "  help              Show this help message"
+    Write-Host "  version           Show version"
+    Write-Host ""
+    Write-Color -Message "RUN OPTIONS:" -Color "White"
+    Write-Host "  --no-cache        Force review all files, ignoring cache"
+    Write-Host "  --ci              CI mode: review files changed in last commit"
+    Write-Host "  --pr-mode         PR mode: review all files changed in PR"
+    Write-Host "  --diff-only       With --pr-mode: send only diffs"
+    Write-Host "  --commit-msg-file Path to commit message file (commit-msg hook)"
+    Write-Host ""
+    Write-Color -Message "CONFIGURATION:" -Color "White"
+    Write-Host "  Create a .gga file in your project root or"
+    Write-Host "  `$env:USERPROFILE\.config\gga\.gga for global settings."
+    Write-Host ""
+    Write-Color -Message "CONFIG OPTIONS:" -Color "White"
+    Write-Host "  PROVIDER           AI provider (claude, gemini, codex, opencode,"
+    Write-Host "                     ollama:<model>, lmstudio[:model], github:<model>)"
+    Write-Host "  FILE_PATTERNS      File patterns to review (default: *)"
+    Write-Host "  EXCLUDE_PATTERNS   Patterns to exclude"
+    Write-Host "  RULES_FILE         File with review rules (default: AGENTS.md)"
+    Write-Host "  STRICT_MODE        Fail on ambiguous AI response (default: true)"
+    Write-Host "  TIMEOUT            Max seconds for AI response (default: 300)"
+    Write-Host ""
+}
+
+function Get-Version {
+    Write-Host "gga v$VERSION"
+}
+
+function Write-TextFileNoBom {
+    param(
+        [string]$Path,
+        [string]$Content
+    )
+
+    $normalizedContent = $Content -replace "`r`n", "`n"
+    $resolvedPath = if ([System.IO.Path]::IsPathRooted($Path)) {
+        $Path
+    } else {
+        Join-Path (Get-Location) $Path
+    }
+    $parentDir = Split-Path -Path $resolvedPath -Parent
+    if ($parentDir -and -not (Test-Path $parentDir)) {
+        New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+    }
+    [System.IO.File]::WriteAllText($resolvedPath, $normalizedContent, (New-Object System.Text.UTF8Encoding($false)))
+}
+
+function Load-Config {
+    $script:PROVIDER = ""
+    $script:FILE_PATTERNS = "*"
+    $script:EXCLUDE_PATTERNS = ""
+    $script:RULES_FILE = "AGENTS.md"
+    $script:STRICT_MODE = $true
+    $script:TIMEOUT = 300
+    $script:PR_BASE_BRANCH = ""
+
+    function Set-ConfigValue {
+        param(
+            [string]$Key,
+            [string]$Value
+        )
+
+        $normalizedKey = $Key.Trim().ToUpperInvariant()
+        $normalizedValue = $Value.Trim()
+
+        if (
+            ($normalizedValue.StartsWith('"') -and $normalizedValue.EndsWith('"')) -or
+            ($normalizedValue.StartsWith("'") -and $normalizedValue.EndsWith("'"))
+        ) {
+            $normalizedValue = $normalizedValue.Substring(1, $normalizedValue.Length - 2)
+        }
+
+        switch ($normalizedKey) {
+            "PROVIDER" { $script:PROVIDER = $normalizedValue }
+            "FILE_PATTERNS" { $script:FILE_PATTERNS = $normalizedValue }
+            "EXCLUDE_PATTERNS" { $script:EXCLUDE_PATTERNS = $normalizedValue }
+            "RULES_FILE" { $script:RULES_FILE = $normalizedValue }
+            "STRICT_MODE" { $script:STRICT_MODE = ($normalizedValue -match '^(?i:true|1|yes|y)$') }
+            "TIMEOUT" {
+                $timeoutValue = 0
+                if ([int]::TryParse($normalizedValue, [ref]$timeoutValue) -and $timeoutValue -gt 0) {
+                    $script:TIMEOUT = $timeoutValue
+                }
+            }
+            "PR_BASE_BRANCH" { $script:PR_BASE_BRANCH = $normalizedValue }
+        }
+    }
+
+    function Import-ConfigFile {
+        param([string]$Path)
+
+        if (-not (Test-Path -Path $Path -PathType Leaf)) {
+            return
+        }
+
+        Get-Content -Path $Path | ForEach-Object {
+            $line = $_.Trim()
+            if (-not $line -or $line.StartsWith("#")) {
+                return
+            }
+            $separatorIndex = $line.IndexOf("=")
+            if ($separatorIndex -lt 1) {
+                return
+            }
+            $key = $line.Substring(0, $separatorIndex).Trim()
+            $value = $line.Substring($separatorIndex + 1).Trim()
+            Set-ConfigValue -Key $key -Value $value
+        }
+    }
+
+    $globalConfig = Join-Path $env:USERPROFILE ".config\gga\config"
+    $globalConfigAlt = Join-Path $env:USERPROFILE ".config\gga\.gga"
+    Import-ConfigFile -Path $globalConfig
+    Import-ConfigFile -Path $globalConfigAlt
+
+    $projectConfig = ".gga"
+    Import-ConfigFile -Path $projectConfig
+
+    if ($env:GGA_PROVIDER) { $script:PROVIDER = $env:GGA_PROVIDER }
+    if ($env:GGA_TIMEOUT) {
+        $envTimeout = 0
+        if ([int]::TryParse($env:GGA_TIMEOUT, [ref]$envTimeout) -and $envTimeout -gt 0) {
+            $script:TIMEOUT = $envTimeout
+        }
+    }
+}
+
+function Get-ConfigFilesForCache {
+    $globalConfig = Join-Path $env:USERPROFILE ".config\gga\config"
+    $globalConfigAlt = Join-Path $env:USERPROFILE ".config\gga\.gga"
+    return @(".gga", $globalConfig, $globalConfigAlt)
+}
+
+function Show-Config {
+    Write-Banner
+    Load-Config
+
+    Write-Color -Message "Current Configuration:" -Color "White"
+    Write-Host ""
+
+    $globalConfig = Join-Path $env:USERPROFILE ".config\gga\config"
+    $globalConfigAlt = Join-Path $env:USERPROFILE ".config\gga\.gga"
+    $projectConfig = ".gga"
+
+    Write-Color -Message "Config Files:" -Color "White"
+    if (Test-Path -Path $globalConfig -PathType Leaf) {
+        Write-Color "  Global:  $globalConfig" "Green"
+    } elseif (Test-Path -Path $globalConfigAlt -PathType Leaf) {
+        Write-Color "  Global:  $globalConfigAlt" "Green"
+    } else {
+        Write-Color "  Global:  Not found" "Yellow"
+    }
+    if (Test-Path -Path $projectConfig -PathType Leaf) {
+        Write-Color "  Project: $projectConfig" "Green"
+    } else {
+        Write-Color "  Project: Not found" "Yellow"
+    }
+    Write-Host ""
+
+    Write-Color -Message "Values:" -Color "White"
+    if ($script:PROVIDER) {
+        Write-Color "  PROVIDER:          $($script:PROVIDER)" "Green"
+    } else {
+        Write-Color "  PROVIDER:          Not configured" "Red"
+    }
+    Write-Color "  FILE_PATTERNS:     $($script:FILE_PATTERNS)" "Cyan"
+    if ($script:EXCLUDE_PATTERNS) {
+        Write-Color "  EXCLUDE_PATTERNS:  $($script:EXCLUDE_PATTERNS)" "Cyan"
+    } else {
+        Write-Color "  EXCLUDE_PATTERNS:  None" "Yellow"
+    }
+    Write-Color "  RULES_FILE:        $($script:RULES_FILE)" "Cyan"
+    Write-Color "  STRICT_MODE:       $($script:STRICT_MODE)" "Cyan"
+    Write-Color "  TIMEOUT:           $($script:TIMEOUT)s" "Cyan"
+    if ($script:PR_BASE_BRANCH) {
+        Write-Color "  PR_BASE_BRANCH:    $($script:PR_BASE_BRANCH)" "Cyan"
+    } else {
+        Write-Color "  PR_BASE_BRANCH:    auto-detect" "Yellow"
+    }
+    Write-Host ""
+
+    if (Test-Path $script:RULES_FILE) {
+        Write-Color "Rules File: Found" "Green"
+    } else {
+        Write-Color "Rules File: Not found ($($script:RULES_FILE))" "Red"
+    }
+    Write-Host ""
+}
+
+function Initialize-Config {
+    Write-Banner
+
+    $projectConfig = ".gga"
+
+    if (Test-Path $projectConfig) {
+        Write-Color "Config file already exists: $projectConfig" "Yellow"
+        $confirm = Read-Host "Overwrite? (y/N)"
+        if ($confirm -ne "y" -and $confirm -ne "Y") {
+            Write-Host "Aborted."
+            exit 0
+        }
+    }
+
+    @"
+# Gentleman Guardian Angel Configuration
+# https://github.com/your-org/gga
+
+# AI Provider (required)
+# Options: claude, gemini, codex, opencode, ollama:<model>, lmstudio[:model], github:<model>
+PROVIDER="claude"
+
+# File patterns to include in review (comma-separated)
+FILE_PATTERNS="*.ts,*.tsx,*.js,*.jsx"
+
+# File patterns to exclude from review (comma-separated)
+EXCLUDE_PATTERNS="*.test.ts,*.spec.ts,*.test.tsx,*.spec.tsx,*.d.ts"
+
+# File containing code review rules
+RULES_FILE="AGENTS.md"
+
+# Strict mode: fail if AI response is ambiguous
+STRICT_MODE="true"
+
+# Timeout in seconds for AI provider response
+TIMEOUT="300"
+
+# Base branch for --pr-mode (auto-detects main/master/develop if empty)
+# PR_BASE_BRANCH="main"
+"@ | Out-File -FilePath $projectConfig -Encoding utf8
+
+    Write-Color "Created config file: $projectConfig" "Green"
+    Write-Host ""
+    Write-Color "Next steps:" "Blue"
+    Write-Host "  1. Edit $projectConfig to set your preferred provider"
+    Write-Host "  2. Create $($script:RULES_FILE) with your coding standards"
+    Write-Host "  3. Run: gga install"
+    Write-Host ""
+}
+
+function Install-Hook {
+    param([string]$HookType = "pre-commit")
+
+    Write-Banner
+
+    $gitRoot = git rev-parse --show-toplevel 2>$null
+    if (-not $gitRoot) {
+        Write-Color "Not a git repository" "Red"
+        exit 1
+    }
+
+    $hooksDir = (git rev-parse --git-path hooks 2>$null | Select-Object -First 1).Trim()
+    if (-not $hooksDir) {
+        $hooksDir = Join-Path $gitRoot ".git\hooks"
+    }
+    if (-not (Test-Path $hooksDir)) {
+        New-Item -ItemType Directory -Path $hooksDir -Force | Out-Null
+    }
+
+    $hookPath = Join-Path $hooksDir $HookType
+    $runCommand = if ($HookType -eq "commit-msg") { 'gga run \"$1\"' } else { "gga run" }
+
+    $GGA_MARKER_START = "# ======== GGA START ========"
+    $GGA_MARKER_END = "# ======== GGA END ========"
+
+    if (Test-Path $hookPath) {
+        $content = Get-Content $hookPath -Raw
+        if ($content -match [regex]::Escape($GGA_MARKER_START)) {
+            Write-Color "Gentleman Guardian Angel hook already installed in $HookType" "Yellow"
+            exit 0
+        }
+
+        if ($content -match "ai-code-review") {
+            Write-Color "Found legacy 'ai-code-review' in hook, migrating to 'gga'..." "Yellow"
+            $content = $content -replace "ai-code-review", "gga"
+            $content = $content -replace "AI Code Review", "Gentleman Guardian Angel"
+            Write-TextFileNoBom -Path $hookPath -Content $content
+            Write-Color "Migrated hook to use 'gga'" "Green"
+            exit 0
+        }
+
+        Write-Color "Existing $HookType hook found, appending GGA..." "Blue"
+        $ggaBlock = @"
+
+$GGA_MARKER_START
+# Gentleman Guardian Angel - Code Review
+if command -v pwsh >/dev/null 2>&1; then
+  pwsh -NoProfile -ExecutionPolicy Bypass -Command "$runCommand"
+  rc=`$?
+else
+  powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$runCommand"
+  rc=`$?
+fi
+[ `$rc -eq 0 ] || exit 1
+$GGA_MARKER_END
+"@
+        if ($content -match '(?m)^\s*exit\s*\d*\s*$') {
+            $lines = $content -split "`r?`n"
+            $lastExitIdx = -1
+            for ($i = $lines.Length - 1; $i -ge 0; $i--) {
+                if ($lines[$i] -match '^\s*exit\s*\d*\s*$') {
+                    $lastExitIdx = $i
+                    break
+                }
+            }
+            if ($lastExitIdx -ge 0) {
+                $before = if ($lastExitIdx -gt 0) { ($lines[0..($lastExitIdx - 1)] -join "`n") } else { "" }
+                $after = $lines[$lastExitIdx..($lines.Length - 1)] -join "`n"
+                $content = ($before + "`n" + $ggaBlock + "`n" + $after).TrimStart("`n")
+            } else {
+                $content += $ggaBlock
+            }
+        } else {
+            $content += $ggaBlock
+        }
+        Write-TextFileNoBom -Path $hookPath -Content $content
+        Write-Color "Appended Gentleman Guardian Angel to existing $HookType hook: $hookPath" "Green"
+        exit 0
+    }
+
+    $hookScript = @"
+#!/bin/sh
+
+$GGA_MARKER_START
+# Gentleman Guardian Angel - Code Review
+if command -v pwsh >/dev/null 2>&1; then
+  pwsh -NoProfile -ExecutionPolicy Bypass -Command "$runCommand"
+  rc=`$?
+else
+  powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$runCommand"
+  rc=`$?
+fi
+[ `$rc -eq 0 ] || exit 1
+$GGA_MARKER_END
+"@
+    Write-TextFileNoBom -Path $hookPath -Content $hookScript
+
+    Write-Color "Installed $HookType hook: $hookPath" "Green"
+    Write-Host ""
+}
+
+function Uninstall-Hook {
+    Write-Banner
+
+    $gitRoot = git rev-parse --show-toplevel 2>$null
+    if (-not $gitRoot) {
+        Write-Color "Not a git repository" "Red"
+        exit 1
+    }
+
+    $hooksDir = (git rev-parse --git-path hooks 2>$null | Select-Object -First 1).Trim()
+    if (-not $hooksDir) {
+        $hooksDir = Join-Path $gitRoot ".git\hooks"
+    }
+    $foundAny = $false
+
+    foreach ($hookType in @("pre-commit", "commit-msg")) {
+        $hookPath = Join-Path $hooksDir $hookType
+        if (-not (Test-Path $hookPath)) {
+            continue
+        }
+
+        $content = Get-Content $hookPath -Raw
+        if ($content -match [regex]::Escape("# ======== GGA START ========")) {
+            $foundAny = $true
+            $content = $content -replace '(?s)# ======== GGA START ========.*?# ======== GGA END ========\r?\n?', ''
+            $content = $content -replace '(?s)# Gentleman Guardian Angel.*?(pwsh|powershell\.exe).*?\r?\n?', ''
+            $trimmedContent = $content.Trim()
+            $contentWithoutShebang = $trimmedContent -replace '(?m)^#!.*\r?\n?', ''
+
+            if ($trimmedContent -match '^\s*#!\s*/' -and $contentWithoutShebang.Trim()) {
+                Write-TextFileNoBom -Path $hookPath -Content $trimmedContent
+                Write-Color "Removed Gentleman Guardian Angel from $hookType hook" "Green"
+            } else {
+                Remove-Item $hookPath -Force
+                Write-Color "Removed $hookType hook (was GGA-only)" "Green"
+            }
+        } elseif ($content -match '(?m)^\s*gga\s+run') {
+            $foundAny = $true
+            $content = $content -replace '(?m)^\s*#\s*Gentleman Guardian Angel.*\r?\n?', ''
+            $content = $content -replace '(?m)^\s*gga\s+run.*\r?\n?', ''
+            $trimmedContent = $content.Trim()
+            $contentWithoutShebang = $trimmedContent -replace '(?m)^#!.*\r?\n?', ''
+
+            if ($trimmedContent -match '^\s*#!\s*/' -and $contentWithoutShebang.Trim()) {
+                Write-TextFileNoBom -Path $hookPath -Content $trimmedContent
+                Write-Color "Removed Gentleman Guardian Angel from $hookType hook" "Green"
+            } else {
+                Remove-Item $hookPath -Force
+                Write-Color "Removed $hookType hook (was GGA-only)" "Green"
+            }
+        }
+    }
+
+    if (-not $foundAny) {
+        Write-Color "Gentleman Guardian Angel hook not found" "Yellow"
+    }
+    Write-Host ""
+}
+
+function Clear-Cache {
+    param([string]$SubCommand = "status")
+
+    Write-Banner
+    Load-Config
+    $configFiles = Get-ConfigFilesForCache
+
+    switch ($SubCommand) {
+        "clear" {
+            Clear-Project-Cache
+            Write-Color "Cleared cache for current project" "Green"
+            Write-Host ""
+        }
+        "clear-all" {
+            Clear-All-Cache
+            Write-Color "Cleared all cache data" "Green"
+            Write-Host ""
+        }
+        "status" {
+            $cacheDir = Get-ProjectCacheDir
+
+            Write-Color -Message "Cache Status:" -Color "White"
+            Write-Host ""
+
+            if (-not $cacheDir) {
+                Write-Color "  Project cache: Not initialized (not in a git repo?)" "Yellow"
+            } elseif (-not (Test-Path $cacheDir)) {
+                Write-Color "  Project cache: Not initialized" "Yellow"
+            } else {
+                Write-Color "  Cache directory: $cacheDir" "Cyan"
+
+                if (Test-Cache-Valid $script:RULES_FILE $configFiles) {
+                    Write-Color "  Cache validity: Valid" "Green"
+                } else {
+                    Write-Color "  Cache validity: Invalid (rules or config changed)" "Yellow"
+                }
+
+                $filesDir = Join-Path $cacheDir "files"
+                if (Test-Path $filesDir) {
+                    $cachedCount = (Get-ChildItem $filesDir -File).Count
+                    Write-Color "  Cached files: $cachedCount" "Cyan"
+                }
+
+                $cacheSize = (Get-ChildItem $cacheDir -Recurse -File | Measure-Object -Property Length -Sum).Sum
+                if ($cacheSize) {
+                    $sizeStr = "{0:N2} MB" -f ($cacheSize / 1MB)
+                    Write-Color "  Cache size: $sizeStr" "Cyan"
+                }
+            }
+            Write-Host ""
+        }
+        default {
+            Write-Color "Unknown cache command: $SubCommand" "Red"
+            Write-Host ""
+            Write-Host "Available commands:"
+            Write-Host "  gga cache status     - Show cache status"
+            Write-Host "  gga cache clear      - Clear project cache"
+            Write-Host "  gga cache clear-all  - Clear all cache"
+            Write-Host ""
+            exit 1
+        }
+    }
+}
+
+function Invoke-Run {
+    param(
+        [switch]$NoCache,
+        [switch]$Ci,
+        [switch]$PrMode,
+        [switch]$DiffOnly,
+        [string]$CommitMsgFile = ""
+    )
+
+    if (-not (Validate-PrModeFlags $PrMode $DiffOnly)) {
+        exit 1
+    }
+
+    Write-Banner
+    Load-Config
+    $configFiles = Get-ConfigFilesForCache
+
+    if (-not $script:PROVIDER) {
+        Write-Color "No provider configured" "Red"
+        Write-Host ""
+        Write-Host "Configure a provider in .gga or set `$env:GGA_PROVIDER"
+        Write-Host "Run 'gga init' to create a config file"
+        Write-Host ""
+        exit 1
+    }
+
+    if (-not (Test-Provider $script:PROVIDER)) {
+        exit 1
+    }
+
+    if (-not (Test-Path $script:RULES_FILE)) {
+        Write-Color "Rules file not found: $($script:RULES_FILE)" "Red"
+        Write-Host ""
+        Write-Host "Please create a $($script:RULES_FILE) file with your coding standards."
+        Write-Host ""
+        exit 1
+    }
+
+    $useCache = -not $NoCache
+    if ($Ci -or $PrMode) { $useCache = $false }
+
+    Write-Color "Provider: $($script:PROVIDER)" "Blue"
+    Write-Color "Rules file: $($script:RULES_FILE)" "Blue"
+    Write-Color "File patterns: $($script:FILE_PATTERNS)" "Blue"
+    if ($script:EXCLUDE_PATTERNS) {
+        Write-Color "Exclude patterns: $($script:EXCLUDE_PATTERNS)" "Blue"
+    }
+
+    if ($PrMode) {
+        if ($DiffOnly) {
+            Write-Color "Mode: PR (diff-only review)" "Cyan"
+        } else {
+            Write-Color "Mode: PR (full file review)" "Cyan"
+        }
+    } elseif ($Ci) {
+        Write-Color "Mode: CI (reviewing last commit)" "Cyan"
+    }
+    Write-Host ""
+
+    if ($useCache) {
+        Write-Color "Cache: enabled" "Green"
+    } elseif ($PrMode) {
+        Write-Color "Cache: disabled (PR mode)" "Yellow"
+    } elseif ($Ci) {
+        Write-Color "Cache: disabled (CI mode)" "Yellow"
+    } else {
+        Write-Color "Cache: disabled (--no-cache)" "Yellow"
+    }
+    Write-Host ""
+
+    $filesToCheck = ""
+    $prRange = ""
+    $prBase = ""
+
+    if ($PrMode) {
+        $prRange = Get-PrRange $script:PR_BASE_BRANCH
+        if (-not $prRange) {
+            Write-Color "Could not determine PR range" "Red"
+            Write-Host ""
+            Write-Host "Set PR_BASE_BRANCH in your .gga config to specify the base branch."
+            Write-Host ""
+            exit 1
+        }
+        $prBase = ($prRange -split '\.\.\.')[0]
+        Write-Color "PR range: $prRange" "Cyan"
+        $filesToCheck = Get-PrFiles $prRange $script:FILE_PATTERNS $script:EXCLUDE_PATTERNS
+        if (-not $filesToCheck) {
+            Write-Color "No matching files changed in PR" "Yellow"
+            Write-Host ""
+            exit 0
+        }
+    } elseif ($Ci) {
+        $filesToCheck = Get-CiFiles $script:FILE_PATTERNS $script:EXCLUDE_PATTERNS
+        if (-not $filesToCheck) {
+            Write-Color "No matching files changed in last commit" "Yellow"
+            Write-Host ""
+            exit 0
+        }
+    } else {
+        $filesToCheck = Get-StagedFiles $script:FILE_PATTERNS $script:EXCLUDE_PATTERNS
+        if (-not $filesToCheck) {
+            Write-Color "No matching files staged for commit" "Yellow"
+            Write-Host ""
+            exit 0
+        }
+    }
+
+    $filesToReview = $filesToCheck
+    $cacheInitialized = $false
+
+    if ($useCache) {
+        if (-not (Test-Cache-Valid $script:RULES_FILE $configFiles)) {
+            Write-Color "Cache invalidated (rules or config changed)" "Blue"
+            Invalidate-Cache
+        }
+
+        $cacheDir = Initialize-Cache $script:RULES_FILE $configFiles
+        $cacheInitialized = $true
+
+        $filesToReview = Filter-UncachedFiles $filesToCheck
+    }
+
+    Write-Color -Message "Files to review:" -Color "White"
+    if (-not $filesToReview) {
+        Write-Color "  All files passed from cache!" "Green"
+        Write-Host ""
+        Write-Color "CODE REVIEW PASSED (cached)" "Green"
+        Write-Host ""
+        exit 0
+    }
+
+    $filesToReview | ForEach-Object { Write-Host "  - $_" }
+    Write-Host ""
+
+    $rules = Get-Content $script:RULES_FILE -Raw
+
+    $prompt = ""
+    $commitMsg = ""
+    if ($CommitMsgFile) {
+        if (Test-Path -Path $CommitMsgFile -PathType Leaf) {
+            $commitMsg = Get-Content -Path $CommitMsgFile -Raw
+        } else {
+            Write-Color "Commit message file not found: $CommitMsgFile" "Yellow"
+        }
+    }
+    if ($PrMode) {
+        $prDiff = if ($DiffOnly) { Get-PrDiff $prRange } else { "" }
+        $prompt = Build-PrPrompt $rules $filesToReview $DiffOnly $prDiff $prBase
+    } else {
+        $useStaged = -not $Ci
+        $prompt = Build-Prompt $rules $filesToReview $useStaged $commitMsg
+    }
+
+    Write-Color "Sending to $($script:PROVIDER) for review (timeout: $($script:TIMEOUT)s)..." "Blue"
+    Write-Host ""
+
+    $providerResult = Execute-ProviderWithTimeout $script:PROVIDER $prompt $script:TIMEOUT
+    $result = $providerResult.Output
+    $execStatus = $providerResult.ExitCode
+
+    if ($providerResult.TimedOut) {
+        Write-Color "Provider timed out after $($script:TIMEOUT)s" "Red"
+        Write-Host ""
+        Write-Host "The AI provider did not respond in time."
+        Write-Host "Try: Increase TIMEOUT in .gga config, or review fewer files."
+        Write-Host ""
+        if ($script:STRICT_MODE) { exit 1 }
+        exit 0
+    }
+
+    if ($execStatus -ne 0) {
+        Write-Color "Provider execution failed (exit code: $execStatus)" "Red"
+        if ($result) {
+            Write-Host ""
+            Write-Host $result
+            Write-Host ""
+        }
+        if ($script:STRICT_MODE) { exit 1 }
+        exit 0
+    }
+
+    Write-Host $result
+    Write-Host ""
+
+    $statusCheck = ($result -split "`n" | Select-Object -First 15) -join "`n"
+
+    if ($statusCheck -match "STATUS: PASSED") {
+        if ($cacheInitialized) {
+            Cache-FilesPassed $filesToReview
+        }
+        Write-Color "CODE REVIEW PASSED" "Green"
+        Write-Host ""
+        exit 0
+    } elseif ($statusCheck -match "STATUS: FAILED") {
+        Write-Color "CODE REVIEW FAILED" "Red"
+        Write-Host ""
+        Write-Host "Fix the violations listed above before committing."
+        Write-Host ""
+        exit 1
+    } else {
+        Write-Color "Could not determine review status" "Yellow"
+        if ($script:STRICT_MODE) {
+            Write-Color "STRICT MODE: Failing due to ambiguous response" "Red"
+            Write-Host ""
+            Write-Host "Expected 'STATUS: PASSED' or 'STATUS: FAILED' in the first 15 lines"
+            Write-Host "Set STRICT_MODE=false in config to allow ambiguous responses"
+            Write-Host ""
+            exit 1
+        } else {
+            Write-Color "Allowing commit (STRICT_MODE=false)" "Yellow"
+            Write-Host ""
+            exit 0
+        }
+    }
+}
+
+switch ($cmd) {
+    "run" {
+        $noCache = $allArgs -contains "--no-cache"
+        $ci = $allArgs -contains "--ci"
+        $prMode = $allArgs -contains "--pr-mode"
+        $diffOnly = $allArgs -contains "--diff-only"
+        $commitMsgFile = ""
+        $commitMsgFileIdx = [Array]::IndexOf($allArgs, "--commit-msg-file")
+        if ($commitMsgFileIdx -ge 0 -and ($commitMsgFileIdx + 1) -lt $allArgs.Count) {
+            $commitMsgFile = $allArgs[$commitMsgFileIdx + 1]
+        }
+        if (-not $commitMsgFile -and $allArgs.Count -gt 1) {
+            foreach ($arg in $allArgs[1..($allArgs.Count - 1)]) {
+                if ($arg -notmatch '^--' -and (Test-Path -Path $arg -PathType Leaf)) {
+                    $commitMsgFile = $arg
+                    break
+                }
+            }
+        }
+        Invoke-Run -NoCache:$noCache -Ci:$ci -PrMode:$prMode -DiffOnly:$diffOnly -CommitMsgFile $commitMsgFile
+    }
+    "install" {
+        $hookType = if ($allArgs -contains "--commit-msg") { "commit-msg" } else { "pre-commit" }
+        Install-Hook -HookType $hookType
+    }
+    "uninstall" {
+        Uninstall-Hook
+    }
+    "config" {
+        Show-Config
+    }
+    "init" {
+        Initialize-Config
+    }
+    "cache" {
+        $subCmd = if ($allArgs.Count -gt 1) { $allArgs[1] } else { "status" }
+        Clear-Cache -SubCommand $subCmd
+    }
+    "version" { 
+        Get-Version 
+    }
+    "v" { 
+        Get-Version 
+    }
+    "--version" { 
+        Get-Version 
+    }
+    "help" { 
+        Get-Help 
+    }
+    "h" { 
+        Get-Help 
+    }
+    "--help" { 
+        Get-Help 
+    }
+    "" { 
+        Get-Help 
+    }
+    default {
+        Write-Color "Unknown command: $cmd" "Red"
+        Write-Host ""
+        Get-Help
+        exit 1
+    }
+}

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,121 @@
+# ============================================================================
+# Gentleman Guardian Angel - Windows Installer
+# ============================================================================
+# Installs the gga CLI tool to your system
+# ============================================================================
+
+param(
+    [string]$InstallDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Color {
+    param(
+        [string]$Message = "",
+        [string]$Color = "White",
+        [switch]$Bold
+    )
+    Write-Host $Message -ForegroundColor $Color
+}
+
+Write-Color "" "Cyan"
+Write-Color "============================================================" "Cyan"
+Write-Color "  Gentleman Guardian Angel - Installer" "Cyan"
+Write-Color "============================================================" "Cyan"
+Write-Color "" "Cyan"
+
+$ScriptDir = $PSScriptRoot
+if (-not $ScriptDir) {
+    $ScriptDir = Get-Location
+}
+
+$UserHome = [System.Environment]::GetFolderPath('UserProfile')
+if ($InstallDir -eq "") {
+    $InstallDir = Join-Path $UserHome "bin"
+}
+
+Write-Color "Install directory: $InstallDir" "Blue"
+Write-Color "" "Blue"
+
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+}
+
+$ggaExe = Join-Path $InstallDir "gga.ps1"
+$ggaCmd = Join-Path $InstallDir "gga.cmd"
+
+if (Test-Path $ggaExe) {
+    Write-Color "gga is already installed" "Yellow"
+    $confirm = Read-Host "Reinstall? (y/N)"
+    if ($confirm -ne "y" -and $confirm -ne "Y") {
+        Write-Color "Aborted." "Yellow"
+        exit 0
+    }
+}
+
+$LibInstallDir = Join-Path $UserHome ".local\share\gga\lib"
+if (-not (Test-Path $LibInstallDir)) {
+    New-Item -ItemType Directory -Path $LibInstallDir -Force | Out-Null
+}
+
+$SourceFiles = @{
+    Gga = Join-Path $ScriptDir "bin\gga.ps1"
+    Providers = Join-Path $ScriptDir "lib\providers.ps1"
+    Cache = Join-Path $ScriptDir "lib\cache.ps1"
+    PrMode = Join-Path $ScriptDir "lib\pr_mode.ps1"
+}
+
+foreach ($entry in $SourceFiles.GetEnumerator()) {
+    if (-not (Test-Path -Path $entry.Value -PathType Leaf)) {
+        Write-Color "Error: Source file not found: $($entry.Value)" "Red"
+        exit 1
+    }
+}
+
+Copy-Item $SourceFiles.Gga $ggaExe -Force
+Copy-Item $SourceFiles.Providers (Join-Path $LibInstallDir "providers.ps1") -Force
+Copy-Item $SourceFiles.Cache (Join-Path $LibInstallDir "cache.ps1") -Force
+Copy-Item $SourceFiles.PrMode (Join-Path $LibInstallDir "pr_mode.ps1") -Force
+
+$ggaCmdPath = Join-Path $InstallDir "gga.cmd"
+$cmdContent = "@echo off`npowershell.exe -NoProfile -ExecutionPolicy Bypass -File `"%~dp0gga.ps1`" %*"
+Set-Content $ggaCmdPath -Value $cmdContent -Encoding ascii
+
+Write-Color "Installed gga to $InstallDir" "Green"
+Write-Color "" "Green"
+
+$PathEnv = [System.Environment]::GetEnvironmentVariable("Path", "User")
+$PathEntries = $PathEnv -split ';' | ForEach-Object { $_.Trim() }
+$IsInPath = $PathEntries -contains $InstallDir
+
+if (-not $IsInPath) {
+    Write-Color "$InstallDir is not in your PATH" "Yellow"
+    Write-Color "" "Yellow"
+    Write-Color "Add this line to your PowerShell profile or run:" "Yellow"
+    Write-Color "" "Yellow"
+    Write-Color "  `$env:Path += `";$InstallDir`"" "Cyan"
+    Write-Color "" "Yellow"
+    Write-Color "Or permanently add to user PATH:" "Yellow"
+    Write-Color "  [System.Environment]::SetEnvironmentVariable(`"Path`", `$env:Path + `";$InstallDir`" , `"User`")" "Cyan"
+    Write-Color "" "Yellow"
+}
+
+Write-Color "Getting started:" -Bold
+Write-Color "" -Bold
+Write-Color "  1. Navigate to your project:"
+Write-Color "     cd C:\path\to\your\project"
+Write-Color "" -Bold
+Write-Color "  2. Add to PATH (if not already):"
+Write-Color "     `$env:Path += `";$InstallDir`""
+Write-Color "" -Bold
+Write-Color "  3. Initialize config:"
+Write-Color "     gga init"
+Write-Color "" -Bold
+Write-Color "  4. Create your AGENTS.md with coding standards"
+Write-Color "" -Bold
+Write-Color "  5. Install the git hook:"
+Write-Color "     gga install"
+Write-Color "" -Bold
+Write-Color "  6. You're ready! The hook will run on each commit."
+Write-Color ""

--- a/lib/cache.ps1
+++ b/lib/cache.ps1
@@ -1,0 +1,181 @@
+# ============================================================================
+# Gentleman Guardian Angel - Cache Functions (PowerShell)
+# ============================================================================
+
+$CACHE_DIR = Join-Path $env:USERPROFILE ".cache\gga"
+
+function Get-FileHash256 {
+    param([string]$FilePath)
+    if (Test-Path $FilePath) {
+        (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash
+    } else {
+        ""
+    }
+}
+
+function Get-StringHash256 {
+    param([string]$String)
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($String)
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    $hash = $sha256.ComputeHash($bytes)
+    [System.BitConverter]::ToString($hash) -replace '-', ''
+}
+
+function Get-ProjectId {
+    $gitRoot = git rev-parse --show-toplevel 2>$null
+    if ($gitRoot) {
+        Get-StringHash256 $gitRoot
+    } else {
+        ""
+    }
+}
+
+function Get-MetadataHash {
+    param([string]$RulesFile, [string[]]$ConfigFiles)
+
+    $rulesHash = ""
+    $configHashes = @()
+
+    if (Test-Path $RulesFile) {
+        $rulesHash = Get-FileHash256 $RulesFile
+    }
+
+    foreach ($configFile in $ConfigFiles) {
+        if (Test-Path -Path $configFile -PathType Leaf) {
+            $configHashes += Get-FileHash256 $configFile
+        }
+    }
+
+    $configHashJoined = $configHashes -join ":"
+    Get-StringHash256 "${rulesHash}:${configHashJoined}"
+}
+
+function Get-ProjectCacheDir {
+    $projectId = Get-ProjectId
+    if (-not $projectId) {
+        return ""
+    }
+    return Join-Path $CACHE_DIR $projectId
+}
+
+function Initialize-Cache {
+    param([string]$RulesFile, [string[]]$ConfigFiles)
+
+    $cacheDir = Get-ProjectCacheDir
+    if (-not $cacheDir) {
+        return ""
+    }
+
+    $filesDir = Join-Path $cacheDir "files"
+    if (-not (Test-Path $filesDir)) {
+        New-Item -ItemType Directory -Path $filesDir -Force | Out-Null
+    }
+
+    $metadataHash = Get-MetadataHash $RulesFile $ConfigFiles
+    Set-Content -Path (Join-Path $cacheDir "metadata") -Value $metadataHash
+
+    return $cacheDir
+}
+
+function Test-Cache-Valid {
+    param([string]$RulesFile, [string[]]$ConfigFiles)
+
+    $cacheDir = Get-ProjectCacheDir
+    if (-not $cacheDir -or -not (Test-Path $cacheDir)) {
+        return $false
+    }
+
+    $metadataFile = Join-Path $cacheDir "metadata"
+    if (-not (Test-Path $metadataFile)) {
+        return $false
+    }
+
+    $storedHash = Get-Content $metadataFile -Raw
+    $currentHash = Get-MetadataHash $RulesFile $ConfigFiles
+
+    return $storedHash -eq $currentHash
+}
+
+function Invalidate-Cache {
+    $cacheDir = Get-ProjectCacheDir
+    if ($cacheDir -and (Test-Path $cacheDir)) {
+        Remove-Item -Path $cacheDir -Recurse -Force
+    }
+}
+
+function Test-FileCached {
+    param([string]$File)
+
+    $cacheDir = Get-ProjectCacheDir
+    $filesDir = Join-Path $cacheDir "files"
+    if (-not $cacheDir -or -not (Test-Path $filesDir)) {
+        return $false
+    }
+
+    $fileHash = Get-FileHash256 $File
+    if (-not $fileHash) {
+        return $false
+    }
+
+    $cacheFile = Join-Path $filesDir $fileHash
+    if (Test-Path $cacheFile) {
+        $cachedStatus = Get-Content $cacheFile -Raw
+        return $cachedStatus -eq "PASSED"
+    }
+
+    return $false
+}
+
+function Cache-FileResult {
+    param([string]$File, [string]$Status)
+
+    $cacheDir = Get-ProjectCacheDir
+    if (-not $cacheDir) {
+        return
+    }
+
+    $filesDir = Join-Path $cacheDir "files"
+    if (-not (Test-Path $filesDir)) {
+        New-Item -ItemType Directory -Path $filesDir -Force | Out-Null
+    }
+
+    $fileHash = Get-FileHash256 $File
+    if ($fileHash) {
+        $cacheFile = Join-Path $filesDir $fileHash
+        Set-Content -Path $cacheFile -Value $Status
+    }
+}
+
+function Cache-FilesPassed {
+    param([string]$Files)
+
+    $Files -split "`n" | ForEach-Object {
+        $file = $_.Trim()
+        if ($file) {
+            Cache-FileResult -File $file -Status "PASSED"
+        }
+    }
+}
+
+function Filter-UncachedFiles {
+    param([string]$Files)
+
+    $uncached = @()
+    $Files -split "`n" | ForEach-Object {
+        $file = $_.Trim()
+        if ($file -and -not (Test-FileCached $file)) {
+            $uncached += $file
+        }
+    }
+    $uncached -join "`n"
+}
+
+function Clear-All-Cache {
+    if (Test-Path $CACHE_DIR) {
+        Remove-Item -Path $CACHE_DIR -Recurse -Force
+    }
+}
+
+function Clear-Project-Cache {
+    Invalidate-Cache
+}

--- a/lib/pr_mode.ps1
+++ b/lib/pr_mode.ps1
@@ -1,0 +1,374 @@
+# ============================================================================
+# Gentleman Guardian Angel - PR Mode Functions (PowerShell)
+# ============================================================================
+
+function Detect-BaseBranch {
+    $branches = git for-each-ref --format='%(refname:short)' refs/heads 2>$null
+    if (-not $branches) {
+        Write-Error "Could not detect base branch (not a git repo?)"
+        return ""
+    }
+
+    foreach ($candidate in @("main", "master", "develop", "dev")) {
+        if (($branches -split "`n" | ForEach-Object { $_.Trim() }) -contains $candidate) {
+            return $candidate
+        }
+    }
+
+    Write-Error "Could not detect base branch. No main, master, develop, or dev branch found. Set PR_BASE_BRANCH in your .gga config."
+    return ""
+}
+
+function Get-PrRange {
+    param([string]$PrBaseBranch = "")
+
+    if ($PrBaseBranch) {
+        return "${PrBaseBranch}...HEAD"
+    }
+
+    $base = Detect-BaseBranch
+    if (-not $base) {
+        return ""
+    }
+
+    return "${base}...HEAD"
+}
+
+function Get-PrFiles {
+    param([string]$Range, [string]$Patterns, [string]$Excludes)
+
+    $changed = git diff --name-only --diff-filter=ACM $Range 2>$null
+    if (-not $changed) {
+        return ""
+    }
+
+    $patternArray = $Patterns -split ','
+    $excludeArray = if ($Excludes) { $Excludes -split ',' } else { @() }
+
+    $result = @()
+    $changed -split "`n" | ForEach-Object {
+        $file = $_.Trim()
+        if (-not $file) { return }
+
+        $match = $false
+        $excluded = $false
+
+        foreach ($pattern in $patternArray) {
+            $pattern = $pattern.Trim()
+            if ($pattern -eq "*") {
+                $match = $true
+                break
+            } elseif ($pattern.StartsWith("*")) {
+                $suffix = $pattern.Substring(1)
+                if ($file.EndsWith($suffix)) {
+                    $match = $true
+                    break
+                }
+            } else {
+                if ($file -eq $pattern -or (Split-Path $file -Leaf) -eq $pattern) {
+                    $match = $true
+                    break
+                }
+            }
+        }
+
+        if ($match -and $Excludes) {
+            foreach ($pattern in $excludeArray) {
+                $pattern = $pattern.Trim()
+                if ($pattern.StartsWith("*")) {
+                    $suffix = $pattern.Substring(1)
+                    if ($file.EndsWith($suffix)) {
+                        $excluded = $true
+                        break
+                    }
+                } else {
+                    if ($file -eq $pattern -or (Split-Path $file -Leaf) -eq $pattern) {
+                        $excluded = $true
+                        break
+                    }
+                }
+            }
+        }
+
+        if ($match -and -not $excluded -and (Test-Path $file)) {
+            $result += $file
+        }
+    }
+
+    return $result -join "`n"
+}
+
+function Get-PrDiff {
+    param([string]$Range)
+    git diff $Range 2>$null
+}
+
+function Validate-PrModeFlags {
+    param([bool]$PrMode, [bool]$DiffOnly)
+
+    if ($DiffOnly -and -not $PrMode) {
+        Write-Color "--diff-only can only be used with --pr-mode" "Red"
+        return $false
+    }
+    return $true
+}
+
+function Build-PrPrompt {
+    param(
+        [string]$Rules,
+        [string]$Files,
+        [bool]$DiffOnly,
+        [string]$DiffContent,
+        [string]$BaseBranch
+    )
+
+    $sb = [System.Text.StringBuilder]::new()
+
+    [void]$sb.AppendLine("You are a code reviewer analyzing a pull request against the $BaseBranch branch.")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("=== CODING STANDARDS ===")
+    [void]$sb.AppendLine($Rules)
+    [void]$sb.AppendLine("=== END CODING STANDARDS ===")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("=== PR CONTEXT ===")
+    [void]$sb.AppendLine("This is a pull request review. The following files were changed in this PR (compared to $BaseBranch).")
+    [void]$sb.AppendLine("=== END PR CONTEXT ===")
+
+    if ($DiffOnly -and $DiffContent) {
+        [void]$sb.AppendLine("")
+        [void]$sb.AppendLine("=== PR DIFF ===")
+        [void]$sb.AppendLine($DiffContent)
+        [void]$sb.AppendLine("=== END PR DIFF ===")
+        [void]$sb.AppendLine("")
+        [void]$sb.AppendLine("=== FILES (complete content for context) ===")
+    } else {
+        [void]$sb.AppendLine("")
+        [void]$sb.AppendLine("=== FILES TO REVIEW ===")
+    }
+
+    $Files -split "`n" | ForEach-Object {
+        $file = $_.Trim()
+        if ($file) {
+            [void]$sb.AppendLine("")
+            [void]$sb.AppendLine("--- FILE: $file ---")
+            if (Test-Path $file) {
+                [void]$sb.AppendLine((Get-Content $file -Raw))
+            }
+        }
+    }
+
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("=== END FILES ===")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("**IMPORTANT: Your response MUST include one of these lines near the beginning:**")
+    [void]$sb.AppendLine("STATUS: PASSED")
+    [void]$sb.AppendLine("STATUS: FAILED")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("**If FAILED:** List each violation with:")
+    [void]$sb.AppendLine("- File name")
+    [void]$sb.AppendLine("- Line number (if applicable)")
+    [void]$sb.AppendLine("- Rule violated")
+    [void]$sb.AppendLine("- Description of the issue")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("**If PASSED:** Confirm all files comply with the coding standards.")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("**Begin with STATUS:**")
+
+    return $sb.ToString()
+}
+
+function Build-Prompt {
+    param(
+        [string]$Rules,
+        [string]$Files,
+        [bool]$UseStaged = $true,
+        [string]$CommitMsg = ""
+    )
+
+    $sb = [System.Text.StringBuilder]::new()
+
+    [void]$sb.AppendLine("You are a code reviewer. Analyze the files below and validate they comply with the coding standards provided.")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("=== CODING STANDARDS ===")
+    [void]$sb.AppendLine($Rules)
+    [void]$sb.AppendLine("=== END CODING STANDARDS ===")
+
+    if ($CommitMsg) {
+        [void]$sb.AppendLine("")
+        [void]$sb.AppendLine("=== COMMIT MESSAGE ===")
+        [void]$sb.AppendLine($CommitMsg)
+        [void]$sb.AppendLine("=== END COMMIT MESSAGE ===")
+    }
+
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("=== FILES TO REVIEW ===")
+
+    $Files -split "`n" | ForEach-Object {
+        $file = $_.Trim()
+        if ($file) {
+            [void]$sb.AppendLine("")
+            [void]$sb.AppendLine("--- FILE: $file ---")
+            if ($UseStaged) {
+                $stagedContent = git show ":$file" 2>$null
+                if ($stagedContent) {
+                    [void]$sb.AppendLine($stagedContent)
+                } else {
+                    Write-Color "Could not read staged content for: $file" "Yellow"
+                }
+            } else {
+                if (Test-Path $file) {
+                    [void]$sb.AppendLine((Get-Content $file -Raw))
+                }
+            }
+        }
+    }
+
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("=== END FILES ===")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("**IMPORTANT: Your response MUST include one of these lines near the beginning:**")
+    [void]$sb.AppendLine("STATUS: PASSED")
+    [void]$sb.AppendLine("STATUS: FAILED")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("**If FAILED:** List each violation with:")
+    [void]$sb.AppendLine("- File name")
+    [void]$sb.AppendLine("- Line number (if applicable)")
+    [void]$sb.AppendLine("- Rule violated")
+    [void]$sb.AppendLine("- Description of the issue")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("**If PASSED:** Confirm all files comply with the coding standards.")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("**Begin with STATUS:**")
+
+    return $sb.ToString()
+}
+
+function Get-StagedFiles {
+    param([string]$Patterns, [string]$Excludes)
+
+    $staged = git diff --cached --name-only --diff-filter=ACM 2>$null
+    if (-not $staged) {
+        return ""
+    }
+
+    $patternArray = $Patterns -split ','
+    $excludeArray = if ($Excludes) { $Excludes -split ',' } else { @() }
+
+    $result = @()
+    $staged -split "`n" | ForEach-Object {
+        $file = $_.Trim()
+        if (-not $file) { return }
+
+        $match = $false
+        $excluded = $false
+
+        foreach ($pattern in $patternArray) {
+            $pattern = $pattern.Trim()
+            if ($pattern -eq "*") {
+                $match = $true
+                break
+            } elseif ($pattern.StartsWith("*")) {
+                $suffix = $pattern.Substring(1)
+                if ($file.EndsWith($suffix)) {
+                    $match = $true
+                    break
+                }
+            } else {
+                if ($file -eq $pattern -or (Split-Path $file -Leaf) -eq $pattern) {
+                    $match = $true
+                    break
+                }
+            }
+        }
+
+        if ($match -and $Excludes) {
+            foreach ($pattern in $excludeArray) {
+                $pattern = $pattern.Trim()
+                if ($pattern.StartsWith("*")) {
+                    $suffix = $pattern.Substring(1)
+                    if ($file.EndsWith($suffix)) {
+                        $excluded = $true
+                        break
+                    }
+                } else {
+                    if ($file -eq $pattern -or (Split-Path $file -Leaf) -eq $pattern) {
+                        $excluded = $true
+                        break
+                    }
+                }
+            }
+        }
+
+        if ($match -and -not $excluded) {
+            $result += $file
+        }
+    }
+
+    return $result -join "`n"
+}
+
+function Get-CiFiles {
+    param([string]$Patterns, [string]$Excludes)
+
+    $sourceCommit = if ($env:GGA_CI_SOURCE_COMMIT) { $env:GGA_CI_SOURCE_COMMIT } else { "HEAD~1" }
+
+    $changed = git diff --name-only --diff-filter=ACM "$sourceCommit..HEAD" 2>$null
+    if (-not $changed) {
+        return ""
+    }
+
+    $patternArray = $Patterns -split ','
+    $excludeArray = if ($Excludes) { $Excludes -split ',' } else { @() }
+
+    $result = @()
+    $changed -split "`n" | ForEach-Object {
+        $file = $_.Trim()
+        if (-not $file) { return }
+
+        $match = $false
+        $excluded = $false
+
+        foreach ($pattern in $patternArray) {
+            $pattern = $pattern.Trim()
+            if ($pattern -eq "*") {
+                $match = $true
+                break
+            } elseif ($pattern.StartsWith("*")) {
+                $suffix = $pattern.Substring(1)
+                if ($file.EndsWith($suffix)) {
+                    $match = $true
+                    break
+                }
+            } else {
+                if ($file -eq $pattern -or (Split-Path $file -Leaf) -eq $pattern) {
+                    $match = $true
+                    break
+                }
+            }
+        }
+
+        if ($match -and $Excludes) {
+            foreach ($pattern in $excludeArray) {
+                $pattern = $pattern.Trim()
+                if ($pattern.StartsWith("*")) {
+                    $suffix = $pattern.Substring(1)
+                    if ($file.EndsWith($suffix)) {
+                        $excluded = $true
+                        break
+                    }
+                } else {
+                    if ($file -eq $pattern -or (Split-Path $file -Leaf) -eq $pattern) {
+                        $excluded = $true
+                        break
+                    }
+                }
+            }
+        }
+
+        if ($match -and -not $excluded -and (Test-Path $file)) {
+            $result += $file
+        }
+    }
+
+    return $result -join "`n"
+}

--- a/lib/providers.ps1
+++ b/lib/providers.ps1
@@ -1,0 +1,374 @@
+# ============================================================================
+# Gentleman Guardian Angel - Provider Functions (PowerShell)
+# ============================================================================
+
+$script:ProvidersScriptPath = $MyInvocation.MyCommand.Path
+
+function Test-Provider {
+    param([string]$Provider)
+
+    $baseProvider = ($Provider -split ':')[0]
+
+    switch ($baseProvider) {
+        "claude" {
+            $claudeCmd = Get-Command claude -ErrorAction SilentlyContinue
+            if (-not $claudeCmd) {
+                Write-Color "Claude CLI not found" "Red"
+                Write-Host ""
+                Write-Host "Install Claude Code CLI:"
+                Write-Host "  https://claude.ai/code"
+                Write-Host ""
+                return $false
+            }
+        }
+        "gemini" {
+            $geminiCmd = Get-Command gemini -ErrorAction SilentlyContinue
+            if (-not $geminiCmd) {
+                Write-Color "Gemini CLI not found" "Red"
+                Write-Host ""
+                Write-Host "Install Gemini CLI:"
+                Write-Host "  npm install -g @anthropic-ai/gemini-cli"
+                Write-Host ""
+                return $false
+            }
+        }
+        "codex" {
+            $codexCmd = Get-Command codex -ErrorAction SilentlyContinue
+            if (-not $codexCmd) {
+                Write-Color "Codex CLI not found" "Red"
+                Write-Host ""
+                Write-Host "Install OpenAI Codex CLI:"
+                Write-Host "  npm install -g @openai/codex"
+                Write-Host ""
+                return $false
+            }
+        }
+        "opencode" {
+            $opencodeCmd = Get-Command opencode -ErrorAction SilentlyContinue
+            if (-not $opencodeCmd) {
+                Write-Color "OpenCode CLI not found" "Red"
+                Write-Host ""
+                Write-Host "Install OpenCode CLI:"
+                Write-Host "  https://opencode.ai"
+                Write-Host ""
+                return $false
+            }
+        }
+        "ollama" {
+            $ollamaCmd = Get-Command ollama -ErrorAction SilentlyContinue
+            if (-not $ollamaCmd) {
+                Write-Color "Ollama not found" "Red"
+                Write-Host ""
+                Write-Host "Install Ollama:"
+                Write-Host "  https://ollama.ai/download"
+                Write-Host ""
+                return $false
+            }
+            $model = if ($Provider -match ':(.+)') { $matches[1] } else { "" }
+            if (-not $model) {
+                Write-Color "Ollama requires a model" "Red"
+                Write-Host ""
+                Write-Host "Specify model in provider config:"
+                Write-Host '  PROVIDER="ollama:llama3.2"'
+                Write-Host '  PROVIDER="ollama:codellama"'
+                Write-Host ""
+                return $false
+            }
+        }
+        "lmstudio" {
+            $curlCmd = Get-Command curl -ErrorAction SilentlyContinue
+            if (-not $curlCmd) {
+                Write-Color "curl not found" "Red"
+                Write-Host ""
+                Write-Host "Install curl:"
+                Write-Host "  Most Windows systems have it pre-installed"
+                Write-Host ""
+                return $false
+            }
+        }
+        "github" {
+            $ghCmd = Get-Command gh -ErrorAction SilentlyContinue
+            if (-not $ghCmd) {
+                Write-Color "gh CLI not found" "Red"
+                Write-Host ""
+                Write-Host "Install GitHub CLI:"
+                Write-Host "  https://cli.github.com"
+                Write-Host ""
+                Write-Host "Then authenticate:"
+                Write-Host "  gh auth login"
+                Write-Host ""
+                return $false
+            }
+            $model = if ($Provider -match ':(.+)') { $matches[1] } else { "" }
+            if (-not $model) {
+                Write-Color "GitHub Models requires a model" "Red"
+                Write-Host ""
+                Write-Host "Specify model in provider config:"
+                Write-Host '  PROVIDER="github:gpt-4o"'
+                Write-Host '  PROVIDER="github:deepseek-r1"'
+                Write-Host ""
+                return $false
+            }
+        }
+        default {
+            Write-Color "Unknown provider: $Provider" "Red"
+            Write-Host ""
+            Write-Host "Supported providers:"
+            Write-Host "  - claude"
+            Write-Host "  - gemini"
+            Write-Host "  - codex"
+            Write-Host "  - opencode"
+            Write-Host "  - ollama:<model>"
+            Write-Host "  - lmstudio[:model]"
+            Write-Host "  - github:<model>"
+            Write-Host ""
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function Execute-Provider {
+    param([string]$Provider, [string]$Prompt)
+
+    $baseProvider = ($Provider -split ':')[0]
+
+    switch ($baseProvider) {
+        "claude" { Execute-Claude $Prompt }
+        "gemini" { Execute-Gemini $Prompt }
+        "codex" { Execute-Codex $Prompt }
+        "opencode" {
+            $model = if ($Provider -match ':(.+)') { $matches[1] } else { "" }
+            Execute-Opencode $model $Prompt
+        }
+        "ollama" {
+            $model = if ($Provider -match ':(.+)') { $matches[1] } else { "llama3.2" }
+            Execute-Ollama $model $Prompt
+        }
+        "lmstudio" {
+            $model = if ($Provider -match ':(.+)') { $matches[1] } else { "" }
+            Execute-LmStudio $model $Prompt
+        }
+        "github" {
+            $model = if ($Provider -match ':(.+)') { $matches[1] } else { "" }
+            Execute-GitHubModels $model $Prompt
+        }
+    }
+}
+
+function Execute-Claude {
+    param([string]$Prompt)
+    $Prompt | claude --print 2>&1
+    return $LASTEXITCODE
+}
+
+function Execute-Gemini {
+    param([string]$Prompt)
+    gemini -p $Prompt 2>&1
+    return $LASTEXITCODE
+}
+
+function Execute-Codex {
+    param([string]$Prompt)
+    codex exec $Prompt 2>&1
+    return $LASTEXITCODE
+}
+
+function Execute-Opencode {
+    param([string]$Model, [string]$Prompt)
+    if ($Model) {
+        opencode run --model $Model $Prompt 2>&1
+    } else {
+        opencode run $Prompt 2>&1
+    }
+    return $LASTEXITCODE
+}
+
+function Execute-Ollama {
+    param([string]$Model, [string]$Prompt)
+    $ollamaHost = if ($env:OLLAMA_HOST) { $env:OLLAMA_HOST } else { "http://localhost:11434" }
+
+    $ollamaHost = $ollamaHost.TrimEnd('/')
+
+    try {
+        $body = @{
+            model = $Model
+            prompt = $Prompt
+            stream = $false
+        } | ConvertTo-Json
+
+        $response = Invoke-RestMethod -Uri "$ollamaHost/api/generate" -Method Post -Body $body -ContentType "application/json" -TimeoutSec 300
+        if ($response.response) {
+            Write-Output $response.response
+            return 0
+        } elseif ($response.error) {
+            Write-Error $response.error
+            return 1
+        } else {
+            Write-Error "Unknown response from Ollama"
+            return 1
+        }
+    } catch {
+        Write-Error "Failed to connect to Ollama at $ollamaHost - $_"
+        return 1
+    }
+}
+
+function Execute-LmStudio {
+    param([string]$Model, [string]$Prompt)
+    $lmHost = if ($env:LMSTUDIO_HOST) { $env:LMSTUDIO_HOST } else { "http://localhost:1234/v1" }
+
+    if (-not $lmHost.EndsWith("/v1")) {
+        $lmHost = "$lmHost/v1"
+    }
+
+    if (-not $Model) { $Model = "local-model" }
+
+    try {
+        $body = @{
+            model = $Model
+            messages = @(
+                @{ role = "user"; content = $Prompt }
+            )
+            temperature = 0.7
+            stream = $false
+        } | ConvertTo-Json
+
+        $response = Invoke-RestMethod -Uri "$lmHost/chat/completions" -Method Post -Body $body -ContentType "application/json" -TimeoutSec 300
+        if ($response.choices) {
+            Write-Output $response.choices[0].message.content
+            return 0
+        } else {
+            Write-Error "Unexpected response from LM Studio"
+            return 1
+        }
+    } catch {
+        Write-Error "Failed to connect to LM Studio at $lmHost - $_"
+        return 1
+    }
+}
+
+function Execute-GitHubModels {
+    param([string]$Model, [string]$Prompt)
+
+    $token = gh auth token 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "GitHub CLI authentication failed. Run 'gh auth login'"
+        return 1
+    }
+
+    $endpoint = "https://models.inference.ai.azure.com/chat/completions"
+
+    try {
+        $body = @{
+            model = $Model
+            messages = @(
+                @{ role = "system"; content = "You are a helpful code review assistant." }
+                @{ role = "user"; content = $Prompt }
+            )
+            temperature = 0.2
+        } | ConvertTo-Json
+
+        $headers = @{
+            "Content-Type" = "application/json"
+            "Authorization" = "Bearer $token"
+        }
+
+        $response = Invoke-RestMethod -Uri $endpoint -Method Post -Body $body -Headers $headers -ContentType "application/json" -TimeoutSec 300
+        if ($response.choices) {
+            Write-Output $response.choices[0].message.content
+            return 0
+        } else {
+            Write-Error "Unexpected response from GitHub Models"
+            return 1
+        }
+    } catch {
+        Write-Error "Failed to connect to GitHub Models - $_"
+        return 1
+    }
+}
+
+function Execute-ProviderWithTimeout {
+    param([string]$Provider, [string]$Prompt, [int]$Timeout = 300)
+
+    $baseProvider = ($Provider -split ':')[0]
+
+    Write-Color "Waiting for $baseProvider response (timeout: ${Timeout}s)..." "Blue"
+
+    $job = Start-Job -ScriptBlock {
+        param($p, $pr, $providersPath)
+
+        . $providersPath
+
+        try {
+            $rawOutput = @(Execute-Provider -Provider $p -Prompt $pr 2>&1)
+            $exitCode = 0
+
+            if ($rawOutput.Count -gt 0 -and $rawOutput[-1] -is [int]) {
+                $exitCode = [int]$rawOutput[-1]
+                if ($rawOutput.Count -gt 1) {
+                    $rawOutput = $rawOutput[0..($rawOutput.Count - 2)]
+                } else {
+                    $rawOutput = @()
+                }
+            }
+
+            $outputText = ($rawOutput | ForEach-Object { $_.ToString() }) -join "`n"
+            return [pscustomobject]@{
+                Output = $outputText
+                ExitCode = $exitCode
+                TimedOut = $false
+            }
+        } catch {
+            return [pscustomobject]@{
+                Output = $_.Exception.Message
+                ExitCode = 1
+                TimedOut = $false
+            }
+        }
+    } -ArgumentList $Provider, $Prompt, $script:ProvidersScriptPath
+
+    $completed = Wait-Job $job -Timeout $Timeout
+
+    if ($completed) {
+        $result = Receive-Job $job
+        Remove-Job $job -Force
+
+        if ($result -is [array]) {
+            return $result[-1]
+        }
+        return $result
+    } else {
+        Stop-Job $job
+        Remove-Job $job -Force
+        Write-Color "TIMEOUT: Provider did not respond within $Timeout seconds." "Red"
+        return [pscustomobject]@{
+            Output = ""
+            ExitCode = 124
+            TimedOut = $true
+        }
+    }
+}
+
+function Get-ProviderInfo {
+    param([string]$Provider)
+
+    $baseProvider = ($Provider -split ':')[0]
+    $model = if ($Provider -match ':(.+)') { $matches[1] } else { "" }
+
+    switch ($baseProvider) {
+        "claude" { "Anthropic Claude Code CLI" }
+        "gemini" { "Google Gemini CLI" }
+        "codex" { "OpenAI Codex CLI" }
+        "opencode" {
+            if ($model) { "OpenCode CLI (model: $model)" } else { "OpenCode CLI" }
+        }
+        "ollama" { "Ollama (model: $model)" }
+        "lmstudio" {
+            if ($model) { "LM Studio (model: $model)" } else { "LM Studio" }
+        }
+        "github" { "GitHub Models (model: $model)" }
+        default { "Unknown provider" }
+    }
+}

--- a/spec/integration/hooks_powershell_spec.sh
+++ b/spec/integration/hooks_powershell_spec.sh
@@ -1,0 +1,85 @@
+# shellcheck shell=bash
+
+Describe 'PowerShell hooks install/uninstall'
+  setup() {
+    TEMP_DIR=$(mktemp -d)
+    cd "$TEMP_DIR" || exit 1
+    git init --quiet
+    git config user.email "test@test.com"
+    git config user.name "Test User"
+    GGA_PS1="$PROJECT_ROOT/bin/gga.ps1"
+    PS_CMD="powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"$GGA_PS1\""
+  }
+
+  cleanup() {
+    cd /
+    rm -rf "$TEMP_DIR"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  Describe 'install'
+    It 'creates pre-commit hook at git-path hooks'
+      eval "$PS_CMD install" >/dev/null 2>&1
+      hooks_dir=$(git rev-parse --git-path hooks)
+      The path "$hooks_dir/pre-commit" should be file
+      The contents of file "$hooks_dir/pre-commit" should include "#!/bin/sh"
+      The contents of file "$hooks_dir/pre-commit" should include "command -v pwsh"
+      The contents of file "$hooks_dir/pre-commit" should include "powershell.exe"
+      The contents of file "$hooks_dir/pre-commit" should include "gga run"
+    End
+
+    It 'creates commit-msg hook with positional file argument'
+      eval "$PS_CMD install --commit-msg" >/dev/null 2>&1
+      hooks_dir=$(git rev-parse --git-path hooks)
+      The path "$hooks_dir/commit-msg" should be file
+      The contents of file "$hooks_dir/commit-msg" should include "gga run \\\"\\$1\\\""
+    End
+
+    It 'inserts GGA block before final exit line'
+      cat > .git/hooks/pre-commit << 'EOF'
+#!/bin/sh
+echo "existing"
+exit 0
+EOF
+      eval "$PS_CMD install" >/dev/null 2>&1
+
+      gga_line=$(grep -n "GGA START" .git/hooks/pre-commit | cut -d: -f1)
+      exit_line=$(grep -n "^exit 0" .git/hooks/pre-commit | tail -1 | cut -d: -f1)
+      Assert [ "$gga_line" -lt "$exit_line" ]
+    End
+  End
+
+  Describe 'uninstall'
+    It 'removes marker block from mixed hook and preserves custom lines'
+      cat > .git/hooks/pre-commit << 'EOF'
+#!/bin/sh
+echo "existing"
+# ======== GGA START ========
+# Gentleman Guardian Angel - Code Review
+gga run || exit 1
+# ======== GGA END ========
+echo "after"
+EOF
+      eval "$PS_CMD uninstall" >/dev/null 2>&1
+      The path ".git/hooks/pre-commit" should be file
+      The contents of file ".git/hooks/pre-commit" should include "existing"
+      The contents of file ".git/hooks/pre-commit" should include "after"
+      The contents of file ".git/hooks/pre-commit" should not include "GGA START"
+    End
+
+    It 'removes legacy gga run hook lines'
+      cat > .git/hooks/pre-commit << 'EOF'
+#!/bin/sh
+# Gentleman Guardian Angel - Code Review
+gga run || exit 1
+echo "after"
+EOF
+      eval "$PS_CMD uninstall" >/dev/null 2>&1
+      The path ".git/hooks/pre-commit" should be file
+      The contents of file ".git/hooks/pre-commit" should include "after"
+      The contents of file ".git/hooks/pre-commit" should not include "gga run"
+    End
+  End
+End


### PR DESCRIPTION
## Summary`n- add native PowerShell implementation for Windows: installer, CLI, providers, cache and PR mode`n- make hook install/uninstall worktree-safe via git-path hooks`n- generate hook files as UTF-8 no BOM with /bin/sh wrapper and pwsh->powershell.exe fallback`n- align commit-msg behavior with positional file argument support`n- improve timeout/provider execution reliability in PowerShell`n- add Windows-focused integration coverage for hooks in ShellSpec`n`n## Notes`n- preserves existing shell implementation and adds full Windows path in parallel`n- local make/shellspec could not be executed in this environment because make was unavailable