### PR TITLE
fix: Pass prompts via stdin or temporary files to avoid ARG_MAX errors with large inputs.

### DIFF
--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -236,8 +236,10 @@ execute_gemini() {
     return 1
   fi
   
-  gemini -p "$prompt" 2>&1
-  return $?
+  # Pass prompt via stdin to avoid ARG_MAX "argument list too long" errors
+  # when reviewing large files. Gemini CLI appends -p content to stdin input.
+  printf '%s' "$prompt" | gemini -p "" 2>&1
+  return "${PIPESTATUS[1]}"
 }
 
 is_gemini_authenticated() {
@@ -791,15 +793,25 @@ execute_provider_with_timeout() {
   local timeout="${3:-300}"
   local base_provider="${provider%%:*}"
 
+  # Write prompt to a temp file to avoid hitting the OS ARG_MAX limit.
+  # Passing large prompts as command-line arguments causes "Argument list too long"
+  # because exec() passes args through the kernel with a hard size cap (~2MB).
+  local _prompt_file
+  _prompt_file=$(mktemp "${TMPDIR:-/tmp}/gga_prompt.XXXXXX")
+  printf '%s' "$prompt" > "$_prompt_file"
+
   case "$base_provider" in
     claude)
-      execute_with_timeout "$timeout" "Claude" bash -c "printf '%s' \"\$1\" | claude --print 2>&1" -- "$prompt"
+      # Pass prompt via stdin to avoid ARG_MAX limits
+      execute_with_timeout "$timeout" "Claude" bash -c "claude --print < \"\$1\" 2>&1" -- "$_prompt_file"
       ;;
     gemini)
-      execute_with_timeout "$timeout" "Gemini" gemini -p "$prompt"
+      # -p '' keeps headless/non-interactive mode; prompt arrives via stdin
+      execute_with_timeout "$timeout" "Gemini" bash -c "gemini -p '' < \"\$1\" 2>&1" -- "$_prompt_file"
       ;;
     codex)
-      execute_with_timeout "$timeout" "Codex" codex exec "$prompt"
+      # Pass prompt via stdin to avoid ARG_MAX limits
+      execute_with_timeout "$timeout" "Codex" bash -c "codex exec < \"\$1\" 2>&1" -- "$_prompt_file"
       ;;
     opencode)
       local model="${provider#*:}"
@@ -807,9 +819,9 @@ execute_provider_with_timeout() {
         model=""
       fi
       if [[ -n "$model" ]]; then
-        execute_with_timeout "$timeout" "OpenCode" opencode run --model "$model" "$prompt"
+        execute_with_timeout "$timeout" "OpenCode" bash -c "opencode run --model \"\$1\" < \"\$2\" 2>&1" -- "$model" "$_prompt_file"
       else
-        execute_with_timeout "$timeout" "OpenCode" opencode run "$prompt"
+        execute_with_timeout "$timeout" "OpenCode" bash -c "opencode run < \"\$1\" 2>&1" -- "$_prompt_file"
       fi
       ;;
     ollama)
@@ -843,4 +855,8 @@ execute_provider_with_timeout() {
       execute_with_timeout "$timeout" "$base_provider" execute_provider "$provider" "$prompt"
       ;;
   esac
+
+  local _ec=$?
+  rm -f "$_prompt_file"
+  return $_ec
 }


### PR DESCRIPTION
# Description: Fix "Argument list too long" error for large code reviews
## 🚀 The Problem
When reviewing a large number of files (or very large individual files), **Gentleman Guardian Angel** would crash with an OS-level error: `La lista de argumentos es demasiado larga` (Argument list too long / E2BIG).
This occurred because the full content of all files (the prompt) was being passed as a command-line argument to the provider's CLI (e.g., `gemini -p "$prompt"`). In Linux/Unix systems, there is a hard kernel limit (`ARG_MAX`) for the total size of arguments passed to a new process.
## 🛠️ The Solution
This PR refactors how providers receive data to ensure scalability:
1. **Temporary File Buffer**: The prompt is now written to a temporary file via `mktemp`.
2. **Stdin Redirection**: Provider CLIs (Gemini, Claude, Codex, OpenCode) now read the prompt via **standard input (stdin)** redirection (`< temp_file`). 
   - *Note: The Gemini CLI specifically appends stdin to its input when using `-p ''`*.
3. **Subprocess Isolation**: By passing only the short file path to the internal `bash` subprocess, we completely bypass the `ARG_MAX` limitation.
4. **Automatic Cleanup**: Temporary files are deleted immediately after the provider finishes execution, even if it fails or times out.
## ✅ Changes
- **[lib/providers.sh](cci:7://file:///home/sebamar88/Escritorio/Development/gentleman-guardian-angel/lib/providers.sh:0:0-0:0)**: 
    - Updated [execute_gemini](cci:1://file:///home/sebamar88/Escritorio/Development/gentleman-guardian-angel/lib/providers.sh:225:0-242:1) to use stdin redirection.
    - Heavily refactored [execute_provider_with_timeout](cci:1://file:///home/sebamar88/Escritorio/Development/gentleman-guardian-angel/lib/providers.sh:789:0-861:1) to implement the temp-file + stdin pattern for Claude, Gemini, Codex, and OpenCode.
    - Added comprehensive cleanup logic for the temporary prompt files.
## 🧪 Testing performed
- Verified with a massive 15-file review that previously triggered the `ARG_MAX` error (now processes correctly).
- Ran `shellcheck lib/providers.sh` to ensure no linting regressions.
- Ran `make test-unit` to verify core provider routing and timeout logic remain intact.