### PR TITLE
fix: detect and resolve Oh My Zsh git plugin alias conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 
 > **WSL** is also fully supported — no special configuration needed.
 
+### Oh My Zsh users
+
+If you use [Oh My Zsh](https://ohmyz.sh/) with the `git` plugin enabled (the default), the alias `gga` will conflict with this CLI. You'll see:
+
+```
+git: 'gui' is not a git command. See 'git --help'.
+```
+
+**Fix:** Add this line to your `~/.zshrc` after the Oh My Zsh source line:
+
+```bash
+unalias gga 2>/dev/null
+```
+
+Then run `source ~/.zshrc` or open a new terminal.
+
 ---
 
 ## 🚀 Quick Start

--- a/bin/gga
+++ b/bin/gga
@@ -1177,6 +1177,23 @@ EOF
 # ============================================================================
 
 main() {
+  # Detect Oh My Zsh git plugin alias conflict
+  # OMZ alias: gga='git gui citool --amend'
+  if [[ "$1" == "gui" || "$1" == "citool" ]]; then
+    echo -e "${RED}⚠️  Oh My Zsh alias conflict detected!${NC}"
+    echo ""
+    echo "The 'git' plugin in Oh My Zsh defines: alias gga='git gui citool --amend'"
+    echo "This conflicts with the Gentleman Guardian Angel CLI."
+    echo ""
+    echo "Solution: Add to your ~/.zshrc:"
+    echo "  unalias gga"
+    echo ""
+    echo "Or call gga directly:"
+    echo "  /usr/local/bin/gga <command>"
+    echo "  command gga <command>"
+    exit 1
+  fi
+
   case "${1:-}" in
     run)
       shift

--- a/bin/gga
+++ b/bin/gga
@@ -1273,23 +1273,6 @@ EOF
 # ============================================================================
 
 main() {
-  # Detect Oh My Zsh git plugin alias conflict
-  # OMZ alias: gga='git gui citool --amend'
-  if [[ "$1" == "gui" || "$1" == "citool" ]]; then
-    echo -e "${RED}⚠️  Oh My Zsh alias conflict detected!${NC}"
-    echo ""
-    echo "The 'git' plugin in Oh My Zsh defines: alias gga='git gui citool --amend'"
-    echo "This conflicts with the Gentleman Guardian Angel CLI."
-    echo ""
-    echo "Solution: Add to your ~/.zshrc:"
-    echo "  unalias gga"
-    echo ""
-    echo "Or call gga directly:"
-    echo "  /usr/local/bin/gga <command>"
-    echo "  command gga <command>"
-    exit 1
-  fi
-
   case "${1:-}" in
     run)
       shift

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -127,3 +127,67 @@ If you get "Failed to connect to LM Studio" errors:
    ```bash
    curl http://localhost:1234/v1/models
    ```
+
+---
+
+## Oh My Zsh alias conflict
+
+If you see an error like this when running `gga`:
+
+```
+⚠️  Oh My Zsh alias conflict detected!
+
+The 'git' plugin in Oh My Zsh defines: alias gga='git gui citool --amend'
+This conflicts with the Gentleman Guardian Angel CLI.
+
+Solution: Add to your ~/.zshrc:
+  unalias gga
+
+Or call gga directly:
+  /usr/local/bin/gga <command>
+  command gga <command>
+```
+
+### What's happening
+
+Oh My Zsh's git plugin defines an alias `gga='git gui citool --amend'`. When you type `gga`, your shell expands it to `git gui citool --amend`, which passes "gui" as the first argument to the GGA script.
+
+### How to fix
+
+**Option 1: Remove the alias (recommended)**
+
+Add this to your `~/.zshrc`, **after** the `source $ZSH/oh-my-zsh.sh` line:
+
+```bash
+unalias gga 2>/dev/null
+```
+
+Then reload your shell:
+
+```bash
+source ~/.zshrc
+```
+
+**Option 2: Remove the git plugin from Oh My Zsh**
+
+Edit your `~/.zshrc` and remove `git` from the plugins list:
+
+```bash
+# Before
+plugins=(git docker node)
+
+# After
+plugins=(docker node)
+```
+
+> **Note:** This removes **all** git aliases provided by Oh My Zsh, not just `gga`.
+
+**Option 3: Use `command` to bypass aliases**
+
+Prefix every call with `command` to skip alias expansion:
+
+```bash
+command gga init
+```
+
+This works but you have to remember to do it every time.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -134,23 +134,13 @@ If you get "Failed to connect to LM Studio" errors:
 
 If you see an error like this when running `gga`:
 
-```
-⚠️  Oh My Zsh alias conflict detected!
-
-The 'git' plugin in Oh My Zsh defines: alias gga='git gui citool --amend'
-This conflicts with the Gentleman Guardian Angel CLI.
-
-Solution: Add to your ~/.zshrc:
-  unalias gga
-
-Or call gga directly:
-  /usr/local/bin/gga <command>
-  command gga <command>
+```text
+git: 'gui' is not a git command. See 'git --help'.
 ```
 
 ### What's happening
 
-Oh My Zsh's git plugin defines an alias `gga='git gui citool --amend'`. When you type `gga`, your shell expands it to `git gui citool --amend`, which passes "gui" as the first argument to the GGA script.
+Oh My Zsh's git plugin defines an alias `gga='git gui citool --amend'`. When you type `gga`, your shell expands it before the GGA binary can run. Git receives `git gui citool --amend <your-command>` and fails before GGA has a chance to show its own error message.
 
 ### How to fix
 
@@ -182,12 +172,14 @@ plugins=(docker node)
 
 > **Note:** This removes **all** git aliases provided by Oh My Zsh, not just `gga`.
 
-**Option 3: Use `command` to bypass aliases**
+**Option 3: Call the binary path directly**
 
-Prefix every call with `command` to skip alias expansion:
+Use the installed binary path to bypass shell aliases:
 
 ```bash
-command gga init
+/usr/local/bin/gga init
+# or, on Homebrew Apple Silicon installs:
+/opt/homebrew/bin/gga init
 ```
 
 This works but you have to remember to do it every time.


### PR DESCRIPTION
## Summary
Document the Oh My Zsh `git` plugin alias conflict with the `gga` command.

## Changes
- Add README guidance for Oh My Zsh users.
- Add troubleshooting docs with the real error users see from Git.
- Document safe fixes: `unalias gga`, remove the OMZ `git` plugin, or call the installed binary path directly.

## Testing
- `make lint`

Closes #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for Oh My Zsh users experiencing a `gga` alias conflict.
  * Included troubleshooting steps and multiple ways to resolve command interception issues.
  * Expanded the README with quick shell instructions for fixing the issue and reloading the terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->