### PR TITLE
feat(providers): add support for Cursor Agent CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <strong>Provider-agnostic code review using AI</strong><br>
-  Use Claude, Gemini, Codex, OpenCode, Ollama, LM Studio, GitHub Models, or any AI to enforce your coding standards.<br>
+  Use Claude, Cursor Agent, Gemini, Codex, OpenCode, Ollama, LM Studio, GitHub Models, or any AI to enforce your coding standards.<br>
   Zero dependencies. Pure Bash. Works everywhere.
 </p>
 
@@ -45,7 +45,7 @@ You have coding standards. Your team ignores them. Code reviews catch issues too
 └─────────────────┘     └──────────────┘     └─────────────────┘
 ```
 
-- 🔌 **Provider agnostic** — Claude, Gemini, Codex, OpenCode, Ollama, LM Studio, GitHub Models
+- 🔌 **Provider agnostic** — Claude, Cursor Agent, Gemini, Codex, OpenCode, Ollama, LM Studio, GitHub Models
 - 📦 **Zero dependencies** — Pure Bash, no Node/Python/Go required
 - 🪝 **Git native** — Standard pre-commit hook
 - ⚡ **Smart caching** — Skip unchanged files
@@ -101,6 +101,7 @@ gga install             # Install git hook
 | Provider | Config Value | Installation |
 |----------|-------------|-------------|
 | **Claude** | `claude` | [claude.ai/code](https://claude.ai/code) |
+| **Cursor Agent** | `cursor[:model]` | [cursor.com](https://cursor.com) |
 | **Gemini** | `gemini` | [gemini-cli](https://github.com/google-gemini/gemini-cli) |
 | **Codex** | `codex` | `npm i -g @openai/codex` |
 | **OpenCode** | `opencode` | [opencode.ai](https://opencode.ai) |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -16,6 +16,7 @@ Use whichever AI CLI you have installed:
 | **Gemini**        | `gemini`           | `echo "prompt" \| gemini`         | [github.com/google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli) |
 | **Codex**         | `codex`            | `codex exec "prompt"`             | `npm i -g @openai/codex`                                                           |
 | **OpenCode**      | `opencode`         | `echo "prompt" \| opencode run`   | [opencode.ai](https://opencode.ai)                                                 |
+| **Cursor Agent**  | `cursor[:model]`   | `agent -p "prompt" --output-format text` | [cursor.com](https://cursor.com)                                                   |
 | **Ollama**        | `ollama:<model>`   | `ollama run <model> "prompt"`     | [ollama.ai](https://ollama.ai)                                                     |
 | **LM Studio**     | `lmstudio[:model]` | HTTP API call to local server     | [lmstudio.ai](https://lmstudio.ai)                                                 |
 | **GitHub Models** | `github:<model>`   | HTTP API via `gh auth token`      | [github.com/marketplace/models](https://github.com/marketplace/models)              |
@@ -39,6 +40,12 @@ PROVIDER="opencode"
 
 # Use OpenCode with specific model
 PROVIDER="opencode:anthropic/claude-opus-4-5"
+
+# Use Cursor Agent (default model)
+PROVIDER="cursor"
+
+# Use Cursor Agent with specific model
+PROVIDER="cursor:composer-2"
 
 # Use Ollama with Llama 3.2
 PROVIDER="ollama:llama3.2"
@@ -99,6 +106,18 @@ Google's Gemini CLI. Built into Antigravity IDE.
 
 # Test it works
 echo "Say hello" | gemini
+```
+
+### Cursor Agent
+
+Uses Cursor's built-in Agent CLI to interact with the models via your Cursor account.
+
+```bash
+# Install Cursor Agent CLI
+curl https://cursor.com/install -fsS | bash
+
+# Test it works
+agent -p "Say hello" --output-format text
 ```
 
 ### GitHub Models

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -8,6 +8,7 @@
 # - gemini: Google Gemini CLI
 # - codex: OpenAI Codex CLI
 # - opencode: OpenCode CLI (optional :model)
+# - cursor: Cursor Agent CLI (optional :model)
 # - ollama:<model>: Ollama with specified model
 # - lmstudio[:model]: LM Studio (optional model)
 # - github:<model>: GitHub Models (OpenAI-compatible API)
@@ -66,6 +67,16 @@ validate_provider() {
         echo ""
         echo "Install OpenCode CLI:"
         echo "  https://opencode.ai"
+        echo ""
+        return 1
+      fi
+      ;;
+    cursor)
+      if ! command -v agent &> /dev/null; then
+        echo -e "${RED}❌ Cursor Agent CLI not found${NC}"
+        echo ""
+        echo "Install Cursor Agent CLI:"
+        echo "  curl https://cursor.com/install -fsS | bash"
         echo ""
         return 1
       fi
@@ -155,6 +166,7 @@ validate_provider() {
       echo "  - gemini"
       echo "  - codex"
       echo "  - opencode"
+      echo "  - cursor"
       echo "  - ollama:<model>"
       echo "  - lmstudio[:model]"
       echo "  - github:<model>"
@@ -191,6 +203,13 @@ execute_provider() {
         model=""
       fi
       execute_opencode "$model" "$prompt"
+      ;;
+    cursor)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" ]]; then
+        model=""
+      fi
+      execute_cursor "$model" "$prompt"
       ;;
     ollama)
       local model="${provider#*:}"
@@ -263,6 +282,18 @@ execute_opencode() {
     opencode run --model "$model" "$prompt" 2>&1
   else
     opencode run "$prompt" 2>&1
+  fi
+  return $?
+}
+
+execute_cursor() {
+  local model="$1"
+  local prompt="$2"
+  
+  if [[ -n "$model" ]]; then
+    agent -p "$prompt" --model "$model" --output-format text 2>&1
+  else
+    agent -p "$prompt" --output-format text 2>&1
   fi
   return $?
 }
@@ -639,6 +670,14 @@ get_provider_info() {
         echo "OpenCode CLI (model: $model)"
       fi
       ;;
+    cursor)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" || -z "$model" ]]; then
+        echo "Cursor Agent"
+      else
+        echo "Cursor Agent (model: $model)"
+      fi
+      ;;
     ollama)
       local model="${provider#*:}"
       echo "Ollama (model: $model)"
@@ -811,6 +850,13 @@ execute_provider_with_timeout() {
       else
         execute_with_timeout "$timeout" "OpenCode" opencode run "$prompt"
       fi
+      ;;
+    cursor)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" ]]; then
+        model=""
+      fi
+      execute_with_timeout "$timeout" "Cursor Agent" execute_cursor "$model" "$prompt"
       ;;
     ollama)
       local model="${provider#*:}"


### PR DESCRIPTION
## Summary
Adds Cursor Agent CLI as a first-class provider so GGA can run reviews using a Cursor account in non-interactive mode.

## Changes
- Add provider  in 
- Validate  CLI presence in provider validation
- Execute non-interactive commands via:
  - 
  - 
- Add timeout wrapper path for Cursor provider
- Update docs and examples in  and 
- Use  as documented model example

## Testing
- [ ] Linting shell scripts...
shellcheck bin/gga lib/*.sh passes *(blocked: shellcheck not installed in local environment)*
- [ ] Running all tests...
shellspec passes *(blocked: shellspec not installed in local environment)*

Closes #65