### PR TITLE
fix(codex): resolve stdin hang and parser window for Codex CLI provider

### DIFF
--- a/bin/gga
+++ b/bin/gga
@@ -923,12 +923,13 @@ cmd_run() {
   echo ""
 
   # Parse result
-  # Search for STATUS in the first 15 lines to handle AI responses that include
-  # preamble text (e.g., instruction acknowledgments, markdown formatting)
+  # Search for STATUS anywhere in the output to handle AI responses that include
+  # preamble text (e.g., instruction acknowledgments, markdown formatting,
+  # or CLI session metadata like Codex's ~15-line header)
   # Accepts: "STATUS: PASSED", "**STATUS: PASSED**", etc.
   local status_check
-  status_check=$(echo "$RESULT" | head -n 15)
-  
+  status_check=$(echo "$RESULT" | grep "STATUS:")
+
   if echo "$status_check" | grep -q "STATUS: PASSED"; then
     # Cache the passed files
     if [[ "$cache_initialized" == true ]]; then
@@ -948,7 +949,7 @@ cmd_run() {
     if [[ "$STRICT_MODE" == "true" ]]; then
       log_error "STRICT MODE: Failing due to ambiguous response"
       echo ""
-      echo "Expected 'STATUS: PASSED' or 'STATUS: FAILED' in the first 15 lines"
+      echo "Expected 'STATUS: PASSED' or 'STATUS: FAILED' in the output"
       echo "Set STRICT_MODE=false in config to allow ambiguous responses"
       echo ""
       exit 1

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -249,7 +249,7 @@ execute_codex() {
   
   # Codex uses exec subcommand for non-interactive mode
   # Using --output-last-message to get just the final response
-  codex exec "$prompt" 2>&1
+  codex exec "$prompt" < /dev/null 2>&1
   return $?
 }
 
@@ -799,7 +799,7 @@ execute_provider_with_timeout() {
       execute_with_timeout "$timeout" "Gemini" gemini -p "$prompt"
       ;;
     codex)
-      execute_with_timeout "$timeout" "Codex" codex exec "$prompt"
+      execute_with_timeout "$timeout" "Codex" codex exec "$prompt" < /dev/null
       ;;
     opencode)
       local model="${provider#*:}"

--- a/spec/unit/status_parsing_spec.sh
+++ b/spec/unit/status_parsing_spec.sh
@@ -2,14 +2,14 @@
 
 Describe 'STATUS parsing (Issue #18)'
   # Test the status parsing logic directly
-  # The parsing should find STATUS: PASSED/FAILED in the first 15 lines
+  # The parsing should find STATUS: PASSED/FAILED anywhere in the output
   # and accept markdown formatting like **STATUS: PASSED**
 
   parse_status() {
     local response="$1"
     local status_check
-    status_check=$(echo "$response" | head -n 15)
-    
+    status_check=$(echo "$response" | grep "STATUS:")
+
     if echo "$status_check" | grep -q "STATUS: PASSED"; then
       echo "PASSED"
       return 0
@@ -93,9 +93,10 @@ All checks passed."
     End
   End
 
-  Describe 'STATUS beyond first 15 lines'
-    It 'returns AMBIGUOUS when STATUS is on line 16'
-      # 15 lines of preamble + STATUS on line 16 (should not be found)
+  Describe 'STATUS beyond first 15 lines (Codex CLI preamble scenario)'
+    It 'detects STATUS on line 16 (searches entire output)'
+      # Codex CLI outputs ~15 lines of session metadata before the AI response
+      # The parser must search the entire output, not just the first N lines
       response="Line 1
 Line 2
 Line 3
@@ -112,32 +113,19 @@ Line 13
 Line 14
 Line 15
 STATUS: PASSED"
-      
-      When call parse_status "$response"
-      The output should equal "AMBIGUOUS"
-      The status should be failure
-    End
 
-    It 'detects STATUS on line 15 (boundary)'
-      # 14 lines of preamble + STATUS on line 15 (should be found)
-      response="Line 1
-Line 2
-Line 3
-Line 4
-Line 5
-Line 6
-Line 7
-Line 8
-Line 9
-Line 10
-Line 11
-Line 12
-Line 13
-Line 14
-STATUS: PASSED"
-      
       When call parse_status "$response"
       The output should equal "PASSED"
+      The status should be success
+    End
+
+    It 'detects STATUS on line 30 (deep in output)'
+      # Some providers output extensive metadata before the actual review
+      response="$(printf 'Preamble line\n%.0s' {1..29})
+STATUS: FAILED"
+
+      When call parse_status "$response"
+      The output should equal "FAILED"
       The status should be success
     End
   End


### PR DESCRIPTION
## Summary

Two fixes for the Codex (OpenAI) provider integration:

### Bug 1 — `codex exec` blocks forever on stdin

`codex exec` attempts to read additional input from stdin when available. In GGA's background subshell (`execute_with_timeout`), stdin is inherited but never closes, causing `codex exec` to hang indefinitely until the timeout fires and kills the process with SIGPIPE ("broken pipe").

**Fix:** Add `< /dev/null` to the `codex exec` invocations so stdin is immediately closed.

### Bug 2 — STATUS line not found due to Codex CLI preamble

Codex CLI outputs ~15 lines of session metadata before the AI response:
```
Reading additional input from stdin...
OpenAI Codex v0.118.0 (research preview)
--------
workdir: /path/to/repo
model: gpt-5.4
provider: openai
...
```

GGA's parser searches only the first 15 lines for `STATUS: PASSED/FAILED`. With Codex's preamble consuming those lines, the actual status is never found, causing GGA to report "ambiguous response" and fail in strict mode — even though Codex correctly reviewed the code.

**Fix:** Search the entire output for the STATUS line instead of limiting to the first 15 lines.

## Testing

- Tested with Codex CLI v0.118.0, model gpt-5.4
- GGA v2.8.1 with `PROVIDER="codex"`, `STRICT_MODE="true"`, `TIMEOUT="600"`
- Verified: Codex runs, reviews code against AGENTS.md rules, returns STATUS: PASSED, GGA correctly detects it
- Both fixes verified independently and together

## Note

The `opencode` provider may have the same stdin issue (also passes prompt as CLI argument without closing stdin). Worth checking.