### PR TITLE
fix(run): harden STATUS parsing and codex output normalization

### DIFF
--- a/bin/gga
+++ b/bin/gga
@@ -922,41 +922,40 @@ cmd_run() {
   echo "$RESULT"
   echo ""
 
-  # Parse result
-  # Search for STATUS in the first 15 lines to handle AI responses that include
-  # preamble text (e.g., instruction acknowledgments, markdown formatting)
-  # Accepts: "STATUS: PASSED", "**STATUS: PASSED**", etc.
-  local status_check
-  status_check=$(echo "$RESULT" | head -n 15)
-  
-  if echo "$status_check" | grep -q "STATUS: PASSED"; then
-    # Cache the passed files
-    if [[ "$cache_initialized" == true ]]; then
-      cache_files_passed "$files_to_review"
+  # Parse result status using strict line-based parser to avoid false matches
+  # from echoed instructions (e.g., responses containing both STATUS lines).
+  local parsed_status
+  if parsed_status=$(parse_review_status "$RESULT" 30); then
+    if [[ "$parsed_status" == "PASSED" ]]; then
+      # Cache the passed files
+      if [[ "$cache_initialized" == true ]]; then
+        cache_files_passed "$files_to_review"
+      fi
+      log_success "CODE REVIEW PASSED"
+      echo ""
+      exit 0
+    elif [[ "$parsed_status" == "FAILED" ]]; then
+      log_error "CODE REVIEW FAILED"
+      echo ""
+      echo "Fix the violations listed above before committing."
+      echo ""
+      exit 1
     fi
-    log_success "CODE REVIEW PASSED"
+  fi
+
+  log_warning "Could not determine review status"
+  if [[ "$STRICT_MODE" == "true" ]]; then
+    log_error "STRICT MODE: Failing due to ambiguous response"
     echo ""
-    exit 0
-  elif echo "$status_check" | grep -q "STATUS: FAILED"; then
-    log_error "CODE REVIEW FAILED"
-    echo ""
-    echo "Fix the violations listed above before committing."
+    echo "Expected exactly one line starting with 'STATUS: PASSED' or 'STATUS: FAILED'"
+    echo "in the first 30 lines of provider output."
+    echo "Set STRICT_MODE=false in config to allow ambiguous responses"
     echo ""
     exit 1
   else
-    log_warning "Could not determine review status"
-    if [[ "$STRICT_MODE" == "true" ]]; then
-      log_error "STRICT MODE: Failing due to ambiguous response"
-      echo ""
-      echo "Expected 'STATUS: PASSED' or 'STATUS: FAILED' in the first 15 lines"
-      echo "Set STRICT_MODE=false in config to allow ambiguous responses"
-      echo ""
-      exit 1
-    else
-      log_warning "Allowing commit (STRICT_MODE=false)"
-      echo ""
-      exit 0
-    fi
+    log_warning "Allowing commit (STRICT_MODE=false)"
+    echo ""
+    exit 0
   fi
 }
 
@@ -1104,6 +1103,68 @@ get_ci_files() {
       fi
     fi
   done
+}
+
+# Parse provider review status from response text
+# Returns:
+#   0 + "PASSED" | "FAILED" on stdout when exactly one status is found
+#   1 + "AMBIGUOUS" on stdout when no status or conflicting statuses are found
+#
+# Parsing rules:
+# - Scan only first N lines (default: 30)
+# - Match STATUS only when it appears at line-start (after optional markdown wrappers)
+# - Strip ANSI color codes before matching
+# - If both PASSED and FAILED are present in scan window, treat as ambiguous
+parse_review_status() {
+  local response="$1"
+  local max_lines="${2:-30}"
+  local line_no=0
+  local found_status=""
+  local line
+
+  while IFS= read -r line; do
+    line_no=$((line_no + 1))
+    if [[ "$line_no" -gt "$max_lines" ]]; then
+      break
+    fi
+
+    # Remove ANSI escape codes
+    line=$(printf '%s' "$line" | sed $'s/\x1b\[[0-9;]*[mK]//g')
+
+    # Trim leading/trailing whitespace
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+
+    # Remove common markdown wrappers/prefixes
+    line="${line#\*\*}"
+    line="${line%\*\*}"
+    line="${line#\*}"
+    line="${line%\*}"
+    line="${line#\`}"
+    line="${line%\`}"
+    line="${line#\# }"
+    line="${line#> }"
+
+    # STATUS must begin the normalized line
+    if [[ "$line" =~ ^STATUS:[[:space:]]*(PASSED|FAILED)([^[:alnum:]_].*)?$ ]]; then
+      local candidate="${BASH_REMATCH[1]}"
+
+      if [[ -z "$found_status" ]]; then
+        found_status="$candidate"
+      elif [[ "$found_status" != "$candidate" ]]; then
+        echo "AMBIGUOUS"
+        return 1
+      fi
+    fi
+  done <<< "$response"
+
+  if [[ -n "$found_status" ]]; then
+    echo "$found_status"
+    return 0
+  fi
+
+  echo "AMBIGUOUS"
+  return 1
 }
 
 build_prompt() {

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -246,11 +246,23 @@ is_gemini_authenticated() {
 
 execute_codex() {
   local prompt="$1"
-  
-  # Codex uses exec subcommand for non-interactive mode
-  # Using --output-last-message to get just the final response
-  codex exec "$prompt" 2>&1
-  return $?
+
+  # Codex uses exec subcommand for non-interactive mode.
+  # Capture ONLY the final assistant message to avoid transcript noise
+  # (instructions can include both STATUS lines and confuse parsers).
+  local output_file
+  output_file=$(mktemp "${TEMP:-${TMPDIR:-/tmp}}/gga_codex_last_msg.XXXXXX")
+
+  # Silence Codex event stream and emit only the final message file content.
+  codex exec --output-last-message "$output_file" "$prompt" >/dev/null 2>&1
+  local codex_status=$?
+
+  if [[ -f "$output_file" && -s "$output_file" ]]; then
+    cat "$output_file"
+  fi
+
+  rm -f "$output_file"
+  return $codex_status
 }
 
 execute_opencode() {
@@ -793,13 +805,13 @@ execute_provider_with_timeout() {
 
   case "$base_provider" in
     claude)
-      execute_with_timeout "$timeout" "Claude" bash -c "printf '%s' \"\$1\" | claude --print 2>&1" -- "$prompt"
+      execute_with_timeout "$timeout" "Claude" execute_claude "$prompt"
       ;;
     gemini)
       execute_with_timeout "$timeout" "Gemini" gemini -p "$prompt"
       ;;
     codex)
-      execute_with_timeout "$timeout" "Codex" codex exec "$prompt"
+      execute_with_timeout "$timeout" "Codex" execute_codex "$prompt"
       ;;
     opencode)
       local model="${provider#*:}"

--- a/spec/unit/status_parsing_spec.sh
+++ b/spec/unit/status_parsing_spec.sh
@@ -2,24 +2,53 @@
 
 Describe 'STATUS parsing (Issue #18)'
   # Test the status parsing logic directly
-  # The parsing should find STATUS: PASSED/FAILED in the first 15 lines
-  # and accept markdown formatting like **STATUS: PASSED**
+  # The parsing should find exactly one STATUS verdict in the first 30 lines,
+  # accept markdown formatting like **STATUS: PASSED**, and treat
+  # conflicting verdicts as ambiguous.
 
   parse_status() {
     local response="$1"
-    local status_check
-    status_check=$(echo "$response" | head -n 15)
-    
-    if echo "$status_check" | grep -q "STATUS: PASSED"; then
-      echo "PASSED"
+    local max_lines="${2:-30}"
+    local line_no=0
+    local found_status=""
+    local line
+
+    while IFS= read -r line; do
+      line_no=$((line_no + 1))
+      if [[ "$line_no" -gt "$max_lines" ]]; then
+        break
+      fi
+
+      line=$(printf '%s' "$line" | sed $'s/\x1b\[[0-9;]*[mK]//g')
+      line="${line#"${line%%[![:space:]]*}"}"
+      line="${line%"${line##*[![:space:]]}"}"
+      line="${line#\*\*}"
+      line="${line%\*\*}"
+      line="${line#\*}"
+      line="${line%\*}"
+      line="${line#\`}"
+      line="${line%\`}"
+      line="${line#\# }"
+      line="${line#> }"
+
+      if [[ "$line" =~ ^STATUS:[[:space:]]*(PASSED|FAILED)([^[:alnum:]_].*)?$ ]]; then
+        local candidate="${BASH_REMATCH[1]}"
+        if [[ -z "$found_status" ]]; then
+          found_status="$candidate"
+        elif [[ "$found_status" != "$candidate" ]]; then
+          echo "AMBIGUOUS"
+          return 1
+        fi
+      fi
+    done <<< "$response"
+
+    if [[ -n "$found_status" ]]; then
+      echo "$found_status"
       return 0
-    elif echo "$status_check" | grep -q "STATUS: FAILED"; then
-      echo "FAILED"
-      return 0
-    else
-      echo "AMBIGUOUS"
-      return 1
     fi
+
+    echo "AMBIGUOUS"
+    return 1
   }
 
   Describe 'STATUS on first line'
@@ -93,9 +122,9 @@ All checks passed."
     End
   End
 
-  Describe 'STATUS beyond first 15 lines'
-    It 'returns AMBIGUOUS when STATUS is on line 16'
-      # 15 lines of preamble + STATUS on line 16 (should not be found)
+  Describe 'STATUS beyond first 30 lines'
+    It 'returns AMBIGUOUS when STATUS is on line 31'
+      # 30 lines of preamble + STATUS on line 31 (should not be found)
       response="Line 1
 Line 2
 Line 3
@@ -111,6 +140,21 @@ Line 12
 Line 13
 Line 14
 Line 15
+Line 16
+Line 17
+Line 18
+Line 19
+Line 20
+Line 21
+Line 22
+Line 23
+Line 24
+Line 25
+Line 26
+Line 27
+Line 28
+Line 29
+Line 30
 STATUS: PASSED"
       
       When call parse_status "$response"
@@ -118,8 +162,8 @@ STATUS: PASSED"
       The status should be failure
     End
 
-    It 'detects STATUS on line 15 (boundary)'
-      # 14 lines of preamble + STATUS on line 15 (should be found)
+    It 'detects STATUS on line 30 (boundary)'
+      # 29 lines of preamble + STATUS on line 30 (should be found)
       response="Line 1
 Line 2
 Line 3
@@ -134,6 +178,21 @@ Line 11
 Line 12
 Line 13
 Line 14
+Line 15
+Line 16
+Line 17
+Line 18
+Line 19
+Line 20
+Line 21
+Line 22
+Line 23
+Line 24
+Line 25
+Line 26
+Line 27
+Line 28
+Line 29
 STATUS: PASSED"
       
       When call parse_status "$response"
@@ -157,15 +216,22 @@ No issues found."
       The status should be failure
     End
 
-    It 'handles STATUS in middle of line'
+    It 'returns AMBIGUOUS when STATUS is in middle of line'
       When call parse_status "Review result: STATUS: PASSED - all good"
-      The output should equal "PASSED"
-      The status should be success
+      The output should equal "AMBIGUOUS"
+      The status should be failure
     End
 
-    It 'prioritizes first STATUS found (PASSED before FAILED)'
+    It 'returns AMBIGUOUS when both PASSED and FAILED are present'
       When call parse_status "STATUS: PASSED
-Note: Almost STATUS: FAILED on one check"
+STATUS: FAILED"
+      The output should equal "AMBIGUOUS"
+      The status should be failure
+    End
+
+    It 'strips ANSI sequences before STATUS parsing'
+      response=$'\033[0;32mSTATUS: PASSED\033[0m\nAll good'
+      When call parse_status "$response"
       The output should equal "PASSED"
       The status should be success
     End

--- a/spec/unit/timeout_spec.sh
+++ b/spec/unit/timeout_spec.sh
@@ -157,6 +157,28 @@ Describe 'execute_provider_with_timeout()'
     End
   End
 
+  Describe 'provider routing uses helper functions'
+    It 'routes claude through execute_claude helper'
+      execute_claude() {
+        echo "CLAUDE_FN_CALLED"
+      }
+
+      When call execute_provider_with_timeout "claude" "test" 5
+      The status should eq 0
+      The output should include "CLAUDE_FN_CALLED"
+    End
+
+    It 'routes codex through execute_codex helper'
+      execute_codex() {
+        echo "CODEX_FN_CALLED"
+      }
+
+      When call execute_provider_with_timeout "codex" "test" 5
+      The status should eq 0
+      The output should include "CODEX_FN_CALLED"
+    End
+  End
+
   Describe 'ollama host validation'
     It 'fails with invalid OLLAMA_HOST before attempting execution'
       OLLAMA_HOST="invalid://bad"


### PR DESCRIPTION
## Linked Issue

Closes #73

## PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature or enhancement
- [ ] `type:docs` — Documentation changes only
- [ ] `type:refactor` — Code refactor (no behavior change)
- [ ] `type:chore` — Maintenance (deps, CI, tooling)
- [ ] `type:breaking-change` — Breaking change (add `!` to commit type)

## Summary

- Fixes ambiguous review status parsing by requiring a normalized line-start `STATUS:` verdict in the first 30 lines.
- Treats conflicting `PASSED`/`FAILED` verdicts as ambiguous and updates strict-mode messaging accordingly.
- Routes codex timeout execution through `execute_codex` with `--output-last-message` to suppress transcript noise that can include instruction examples.

## Changes

| File | Change |
|------|--------|
| `bin/gga` | Replaced loose grep-based status detection with strict `parse_review_status()` and updated strict-mode ambiguity handling. |
| `lib/providers.sh` | Updated codex execution to final-message output file mode and routed timeout dispatcher via provider helpers for `claude`/`codex`. |
| `spec/unit/status_parsing_spec.sh` | Tightened parsing tests to line-start semantics, 30-line window, ANSI stripping, and conflict ambiguity behavior. |
| `spec/unit/timeout_spec.sh` | Added routing tests ensuring `execute_provider_with_timeout` uses helper functions for `claude` and `codex`. |

## Test Plan

- [ ] `make lint` (ShellCheck) passes locally *(tool unavailable in this environment)*
- [ ] `make test` passes locally *(tool unavailable in this environment)*
- [ ] `shellspec spec/unit` passes *(shellspec unavailable in this environment)*
- [ ] `shellspec spec/integration/commands_spec.sh` passes *(shellspec unavailable in this environment)*
- [x] Manual testing:
  - Verified `STRICT_MODE=false` and `STRICT_MODE=true` pass with codex after fixes.
  - Verified provider matrix behavior; expected failures remain for unavailable local services.

## Contributor Checklist

- [x] I have linked the issue above with `Closes #N`
- [ ] The linked issue has `status:approved` *(maintainer label required; contributor lacks permission)*
- [x] I have added a `type:*` label to this PR
- [ ] `make lint` passes (ShellCheck)
- [ ] `make test` passes (all unit tests)
- [ ] Integration tests pass
- [x] New functions/commands have tests in `spec/`
- [x] I followed conventional commits (`feat:`, `fix:`, `docs:`, etc.)
- [x] I have NOT added "Co-Authored-By" or AI attribution to commits
- [ ] Breaking changes are documented and use `!` in the commit type (`feat!:`, `fix!:`)

## Notes for Reviewers

Contributor cannot apply `status:approved` on issue #73 due repository permissions. Once a maintainer adds that label, PR policy checks should proceed normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review results are now parsed more reliably, including colored or formatted output, and can detect ambiguous status messages.
* **Bug Fixes**
  * Improved pass/fail handling so only clear `PASSED` or `FAILED` results are accepted.
  * Updated timeout handling to avoid misleading output when provider runs exceed the limit.
* **Tests**
  * Expanded coverage for status parsing boundaries, ambiguous cases, and ANSI-colored output.
  * Adjusted provider execution tests for the updated output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->