### PR TITLE
feat(providers): add unified REASONING variable across all providers

### DIFF
--- a/bin/gga
+++ b/bin/gga
@@ -162,6 +162,11 @@ print_help() {
   echo "  STRICT_MODE        Fail on ambiguous AI response (default: true)"
   echo "  TIMEOUT            Max seconds to wait for AI response (default: 300)"
   echo "  PR_BASE_BRANCH     Base branch for --pr-mode (default: auto-detect)"
+  echo "  REASONING          Reasoning effort for supported providers (default: unset)"
+  echo "                     Values: minimal, low, medium, high, max"
+  echo "                     ✅ opencode, codex, ollama"
+  echo "                     ⚠️  github (reasoning-capable models only)"
+  echo "                     ❌ claude, gemini (no CLI flag — use opencode as proxy)"
   echo ""
   echo -e "${BOLD}EXAMPLES:${NC}"
   echo "  gga init               # Create sample config"
@@ -177,6 +182,7 @@ print_help() {
   echo -e "${BOLD}ENVIRONMENT VARIABLES:${NC}"
   echo "  GGA_PROVIDER      Override provider from config"
   echo "  GGA_TIMEOUT       Override timeout from config (seconds)"
+  echo "  GGA_REASONING     Override REASONING from config"
   echo ""
 }
 
@@ -294,6 +300,11 @@ cmd_config() {
   echo -e "  RULES_FILE:        ${CYAN}$RULES_FILE${NC}"
   echo -e "  STRICT_MODE:       ${CYAN}$STRICT_MODE${NC}"
   echo -e "  TIMEOUT:           ${CYAN}${TIMEOUT}s${NC}"
+  if [[ -n "${REASONING:-}" ]]; then
+    echo -e "  REASONING:         ${CYAN}$REASONING${NC}"
+  else
+    echo -e "  REASONING:         ${YELLOW}Not set${NC}"
+  fi
   if [[ -n "${PR_BASE_BRANCH:-}" ]]; then
     echo -e "  PR_BASE_BRANCH:    ${CYAN}$PR_BASE_BRANCH${NC}"
   else
@@ -371,6 +382,13 @@ STRICT_MODE="true"
 # Default: 300 (5 minutes)
 # Increase for large changesets or slow connections
 TIMEOUT="300"
+
+# Reasoning effort (applies to opencode, codex, ollama, github)
+# Controls how much the model "thinks" before responding.
+# Values: minimal, low, medium, high, max
+# Provider-specific vars (OPENCODE_VARIANT, etc.) take precedence.
+# Not supported for: claude, gemini — use PROVIDER="opencode" instead.
+# REASONING="high"
 
 # Base branch for --pr-mode (auto-detects main/master/develop if empty)
 # Default: auto-detect

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -246,10 +246,23 @@ is_gemini_authenticated() {
 
 execute_codex() {
   local prompt="$1"
+  local flags=()
+  
+  # Provider-specific override
+  [[ -n "${CODEX_REASONING_EFFORT:-}" ]] && flags+=(--config "model_reasoning_effort=$CODEX_REASONING_EFFORT")
+  
+  # REASONING fallback
+  if [[ -z "${CODEX_REASONING_EFFORT:-}" && -n "${REASONING:-}" ]]; then
+    case "$REASONING" in
+      minimal|low)     flags+=(--config "model_reasoning_effort=low") ;;
+      medium)          flags+=(--config "model_reasoning_effort=medium") ;;
+      high)            flags+=(--config "model_reasoning_effort=high") ;;
+      max)             flags+=(--config "model_reasoning_effort=xhigh") ;;
+    esac
+  fi
   
   # Codex uses exec subcommand for non-interactive mode
-  # Using --output-last-message to get just the final response
-  codex exec "$prompt" 2>&1
+  codex exec "${flags[@]}" "$prompt" 2>&1
   return $?
 }
 
@@ -257,12 +270,18 @@ execute_opencode() {
   local model="$1"
   local prompt="$2"
   
-  # OpenCode CLI accepts prompt as positional argument
-  # opencode run [message..] - message is a positional array
+  # Optional variant and agent flags (GGA-prefixed takes precedence)
+  local flags=()
+  [[ -n "${GGA_OPENCODE_VARIANT:-}" ]] && flags+=(--variant "$GGA_OPENCODE_VARIANT")
+  [[ -z "${GGA_OPENCODE_VARIANT:-}" && -n "${OPENCODE_VARIANT:-}" ]] && flags+=(--variant "$OPENCODE_VARIANT")
+  [[ -z "${GGA_OPENCODE_VARIANT:-}" && -z "${OPENCODE_VARIANT:-}" && -n "${REASONING:-}" ]] && flags+=(--variant "$REASONING")
+  [[ -n "${GGA_OPENCODE_AGENT:-}" ]] && flags+=(--agent "$GGA_OPENCODE_AGENT")
+  [[ -z "${GGA_OPENCODE_AGENT:-}" && -n "${OPENCODE_AGENT:-}" ]] && flags+=(--agent "$OPENCODE_AGENT")
+  
   if [[ -n "$model" ]]; then
-    opencode run --model "$model" "$prompt" 2>&1
+    opencode run --model "$model" "${flags[@]}" -- "$prompt" 2>&1
   else
-    opencode run "$prompt" 2>&1
+    opencode run "${flags[@]}" -- "$prompt" 2>&1
   fi
   return $?
 }
@@ -370,10 +389,19 @@ execute_ollama_cli() {
   local model="$1"
   local prompt="$2"
   
+  # REASONING → --think mapping
+  local think_flag=""
+  if [[ -n "${REASONING:-}" ]]; then
+    case "$REASONING" in
+      minimal) think_flag="--think=false" ;;
+      low|medium|high|max) think_flag="--think=true" ;;
+    esac
+  fi
+  
   # Run ollama CLI, suppress stderr (spinner/progress), strip ANSI codes from stdout
   # The 2>/dev/null removes spinner and progress messages
   # The sed removes any remaining ANSI escape sequences
-  ollama run "$model" "$prompt" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g'
+  ollama run ${think_flag:+"$think_flag"} "$model" "$prompt" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g'
   return "${PIPESTATUS[0]}"
 }
 
@@ -543,17 +571,25 @@ execute_github_models() {
   # Build JSON payload safely using python3
   local json_payload
   if ! json_payload=$(printf '%s' "$prompt" | python3 -c "
-import sys, json
+import sys, json, os
 prompt = sys.stdin.read()
 model = sys.argv[1]
-payload = json.dumps({
+reasoning = os.environ.get('REASONING', '')
+payload_dict = {
     'model': model,
     'messages': [
         {'role': 'system', 'content': 'You are a helpful code review assistant.'},
         {'role': 'user', 'content': prompt}
     ],
     'temperature': 0.2
-})
+}
+if reasoning and reasoning in ('low', 'medium', 'high'):
+    payload_dict['reasoning_effort'] = reasoning
+elif reasoning == 'minimal':
+    payload_dict['reasoning_effort'] = 'low'
+elif reasoning == 'max':
+    payload_dict['reasoning_effort'] = 'high'
+payload = json.dumps(payload_dict)
 print(payload)
 " "$model" 2>&1); then
     echo "Error: Failed to build JSON payload" >&2
@@ -799,17 +835,24 @@ execute_provider_with_timeout() {
       execute_with_timeout "$timeout" "Gemini" gemini -p "$prompt"
       ;;
     codex)
-      execute_with_timeout "$timeout" "Codex" codex exec "$prompt"
+      execute_with_timeout "$timeout" "Codex" execute_codex "$prompt"
       ;;
     opencode)
       local model="${provider#*:}"
       if [[ "$model" == "$provider" ]]; then
         model=""
       fi
+      # Optional variant and agent flags (GGA-prefixed takes precedence)
+      local flags=()
+      [[ -n "${GGA_OPENCODE_VARIANT:-}" ]] && flags+=(--variant "$GGA_OPENCODE_VARIANT")
+      [[ -z "${GGA_OPENCODE_VARIANT:-}" && -n "${OPENCODE_VARIANT:-}" ]] && flags+=(--variant "$OPENCODE_VARIANT")
+      [[ -z "${GGA_OPENCODE_VARIANT:-}" && -z "${OPENCODE_VARIANT:-}" && -n "${REASONING:-}" ]] && flags+=(--variant "$REASONING")
+      [[ -n "${GGA_OPENCODE_AGENT:-}" ]] && flags+=(--agent "$GGA_OPENCODE_AGENT")
+      [[ -z "${GGA_OPENCODE_AGENT:-}" && -n "${OPENCODE_AGENT:-}" ]] && flags+=(--agent "$OPENCODE_AGENT")
       if [[ -n "$model" ]]; then
-        execute_with_timeout "$timeout" "OpenCode" opencode run --model "$model" "$prompt"
+        execute_with_timeout "$timeout" "OpenCode" opencode run --model "$model" "${flags[@]}" -- "$prompt"
       else
-        execute_with_timeout "$timeout" "OpenCode" opencode run "$prompt"
+        execute_with_timeout "$timeout" "OpenCode" opencode run "${flags[@]}" -- "$prompt"
       fi
       ;;
     ollama)
@@ -822,6 +865,10 @@ execute_provider_with_timeout() {
       fi
 
       execute_with_timeout "$timeout" "Ollama ($model)" execute_ollama "$model" "$prompt"
+      ;;
+    github)
+      local model="${provider#*:}"
+      execute_with_timeout "$timeout" "GitHub Models ($model)" execute_github_models "$model" "$prompt"
       ;;
     lmstudio)
       local model="${provider#*:}"


### PR DESCRIPTION
## Summary

Add a unified \REASONING\ env var that maps to each provider's native reasoning mechanism, with provider-specific overrides taking precedence.

### Provider mappings

| REASONING | opencode \--variant\ | codex \easoning_effort\ | ollama \--think\ | github \easoning_effort\ |
|---|---|---|---|---|
| minimal | minimal | low | \--think=false\ | low |
| low | low | low | \--think=true\ | low |
| medium | medium | medium | \--think=true\ | medium |
| high | high | high | \--think=true\ | high |
| max | max | xhigh | \--think=true\ | high |

### Changes
- **providers.sh**: REASONING fallback for opencode/codex/ollama/github, plus timeout wrapper mirror
- **bin/gga**: help text, init template, and config display

### Verification
- \ash -n\ syntax check: ✅ passes
- Backward compatible: all providers work without REASONING set
- Precedence: provider-specific vars > REASONING