### PR TITLE
fix(providers): optimal ARG_MAX solution with temp file + stdin pipe

### DIFF
--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -801,8 +801,8 @@ execute_provider_with_timeout() {
     claude|gemini|codex|opencode)
       # Write prompt to temp file ONCE to avoid ARG_MAX limits.
       # This is critical for large PRs that generate prompts > 128KB-256KB.
-      # Only CLI providers need this; API-based providers (ollama, lmstudio)
-      # use curl/HTTP and don't have argv limits.
+      # Only CLI providers are handled here. API-based providers keep their
+      # existing execution path and should be fixed separately if needed.
       local prompt_file
       prompt_file=$(mktemp "${TEMP:-${TMPDIR:-/tmp}}/gga_prompt.XXXXXX")
       printf '%s' "$prompt" > "$prompt_file"

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -785,32 +785,74 @@ execute_with_timeout() {
 
 # Execute provider with timeout and progress feedback
 # Usage: execute_provider_with_timeout <provider> <prompt> <timeout>
+#
+# For CLI providers (claude, gemini, codex, opencode), the prompt is written to a
+# temp file and piped via stdin to avoid ARG_MAX limits on Windows (~8KB-32KB),
+# macOS (~256KB), and Linux (~128KB-2MB). Only the file path (short string) is
+# passed as an argument to execute_with_timeout, never the prompt content.
 execute_provider_with_timeout() {
   local provider="$1"
   local prompt="$2"
   local timeout="${3:-300}"
   local base_provider="${provider%%:*}"
+  local result=0
 
   case "$base_provider" in
-    claude)
-      execute_with_timeout "$timeout" "Claude" bash -c "printf '%s' \"\$1\" | claude --print 2>&1" -- "$prompt"
-      ;;
-    gemini)
-      execute_with_timeout "$timeout" "Gemini" gemini -p "$prompt"
-      ;;
-    codex)
-      execute_with_timeout "$timeout" "Codex" codex exec "$prompt"
-      ;;
-    opencode)
-      local model="${provider#*:}"
-      if [[ "$model" == "$provider" ]]; then
-        model=""
-      fi
-      if [[ -n "$model" ]]; then
-        execute_with_timeout "$timeout" "OpenCode" opencode run --model "$model" "$prompt"
-      else
-        execute_with_timeout "$timeout" "OpenCode" opencode run "$prompt"
-      fi
+    claude|gemini|codex|opencode)
+      # Write prompt to temp file ONCE to avoid ARG_MAX limits.
+      # This is critical for large PRs that generate prompts > 128KB-256KB.
+      # Only CLI providers need this; API-based providers (ollama, lmstudio)
+      # use curl/HTTP and don't have argv limits.
+      local prompt_file
+      prompt_file=$(mktemp "${TEMP:-${TMPDIR:-/tmp}}/gga_prompt.XXXXXX")
+      printf '%s' "$prompt" > "$prompt_file"
+
+      # Ensure cleanup on exit (success, error, or signal).
+      # trap RETURN fires when the function returns for any reason.
+      trap 'rm -f "$prompt_file"' RETURN
+
+      case "$base_provider" in
+        claude)
+          # cat reads from file (path passed as $1), pipes to claude via stdin.
+          # Only the file path (~50 chars) is in argv, not the prompt content.
+          execute_with_timeout "$timeout" "Claude" \
+            bash -c 'cat "$1" | claude --print 2>&1' _ "$prompt_file"
+          result=$?
+          ;;
+        gemini)
+          # gemini -p - reads prompt from stdin
+          execute_with_timeout "$timeout" "Gemini" \
+            bash -c 'cat "$1" | gemini -p - 2>&1' _ "$prompt_file"
+          result=$?
+          ;;
+        codex)
+          # codex exec - reads prompt from stdin
+          execute_with_timeout "$timeout" "Codex" \
+            bash -c 'cat "$1" | codex exec - 2>&1' _ "$prompt_file"
+          result=$?
+          ;;
+        opencode)
+          local model="${provider#*:}"
+          if [[ "$model" == "$provider" ]]; then
+            model=""
+          fi
+          if [[ -n "$model" ]]; then
+            # Pass model as $2 to avoid shell injection (not interpolated in bash -c string).
+            # opencode run (without positional message args) reads from stdin automatically.
+            # NOTE: Do NOT use '-' as opencode doesn't support explicit stdin flag.
+            execute_with_timeout "$timeout" "OpenCode" \
+              bash -c 'cat "$1" | opencode run --model "$2" 2>&1' _ "$prompt_file" "$model"
+          else
+            execute_with_timeout "$timeout" "OpenCode" \
+              bash -c 'cat "$1" | opencode run 2>&1' _ "$prompt_file"
+          fi
+          result=$?
+          ;;
+      esac
+
+      # Cleanup temp file (also handled by trap, but explicit is clearer)
+      rm -f "$prompt_file"
+      trap - RETURN
       ;;
     ollama)
       local model="${provider#*:}"
@@ -843,4 +885,6 @@ execute_provider_with_timeout() {
       execute_with_timeout "$timeout" "$base_provider" execute_provider "$provider" "$prompt"
       ;;
   esac
+
+  return $result
 }

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -804,8 +804,15 @@ execute_provider_with_timeout() {
       # Only CLI providers are handled here. API-based providers keep their
       # existing execution path and should be fixed separately if needed.
       local prompt_file
-      prompt_file=$(mktemp "${TEMP:-${TMPDIR:-/tmp}}/gga_prompt.XXXXXX")
-      printf '%s' "$prompt" > "$prompt_file"
+      if ! prompt_file=$(mktemp "${TEMP:-${TMPDIR:-/tmp}}/gga_prompt.XXXXXX"); then
+        echo "Error: Failed to create temporary prompt file" >&2
+        return 1
+      fi
+      if ! printf '%s' "$prompt" > "$prompt_file"; then
+        echo "Error: Failed to write provider prompt to temporary file" >&2
+        rm -f "$prompt_file"
+        return 1
+      fi
 
       # Ensure cleanup on exit (success, error, or signal).
       # trap RETURN fires when the function returns for any reason.
@@ -813,25 +820,25 @@ execute_provider_with_timeout() {
 
       case "$base_provider" in
         claude)
-          # cat reads from file (path passed as $1), pipes to claude via stdin.
-          # Only the file path (~50 chars) is in argv, not the prompt content.
+          # The wrapper uses exec so the timeout watcher owns the provider process,
+          # not an intermediate shell or pipeline that can survive timeout cleanup.
           # shellcheck disable=SC2016
           execute_with_timeout "$timeout" "Claude" \
-            bash -c 'cat "$1" | claude --print 2>&1' _ "$prompt_file"
+            bash -c 'exec claude --print < "$1"' _ "$prompt_file"
           result=$?
           ;;
         gemini)
-          # gemini -p - reads prompt from stdin
+          # Gemini appends stdin to the non-interactive prompt value.
           # shellcheck disable=SC2016
           execute_with_timeout "$timeout" "Gemini" \
-            bash -c 'cat "$1" | gemini -p - 2>&1' _ "$prompt_file"
+            bash -c 'exec gemini -p "" < "$1"' _ "$prompt_file"
           result=$?
           ;;
         codex)
-          # codex exec - reads prompt from stdin
+          # codex exec - reads prompt from stdin.
           # shellcheck disable=SC2016
           execute_with_timeout "$timeout" "Codex" \
-            bash -c 'cat "$1" | codex exec - 2>&1' _ "$prompt_file"
+            bash -c 'exec codex exec - < "$1"' _ "$prompt_file"
           result=$?
           ;;
         opencode)
@@ -845,11 +852,11 @@ execute_provider_with_timeout() {
             # NOTE: Do NOT use '-' as opencode doesn't support explicit stdin flag.
             # shellcheck disable=SC2016
             execute_with_timeout "$timeout" "OpenCode" \
-              bash -c 'cat "$1" | opencode run --model "$2" 2>&1' _ "$prompt_file" "$model"
+              bash -c 'exec opencode run --model "$2" < "$1"' _ "$prompt_file" "$model"
           else
             # shellcheck disable=SC2016
             execute_with_timeout "$timeout" "OpenCode" \
-              bash -c 'cat "$1" | opencode run 2>&1' _ "$prompt_file"
+              bash -c 'exec opencode run < "$1"' _ "$prompt_file"
           fi
           result=$?
           ;;

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -815,18 +815,21 @@ execute_provider_with_timeout() {
         claude)
           # cat reads from file (path passed as $1), pipes to claude via stdin.
           # Only the file path (~50 chars) is in argv, not the prompt content.
+          # shellcheck disable=SC2016
           execute_with_timeout "$timeout" "Claude" \
             bash -c 'cat "$1" | claude --print 2>&1' _ "$prompt_file"
           result=$?
           ;;
         gemini)
           # gemini -p - reads prompt from stdin
+          # shellcheck disable=SC2016
           execute_with_timeout "$timeout" "Gemini" \
             bash -c 'cat "$1" | gemini -p - 2>&1' _ "$prompt_file"
           result=$?
           ;;
         codex)
           # codex exec - reads prompt from stdin
+          # shellcheck disable=SC2016
           execute_with_timeout "$timeout" "Codex" \
             bash -c 'cat "$1" | codex exec - 2>&1' _ "$prompt_file"
           result=$?
@@ -840,9 +843,11 @@ execute_provider_with_timeout() {
             # Pass model as $2 to avoid shell injection (not interpolated in bash -c string).
             # opencode run (without positional message args) reads from stdin automatically.
             # NOTE: Do NOT use '-' as opencode doesn't support explicit stdin flag.
+            # shellcheck disable=SC2016
             execute_with_timeout "$timeout" "OpenCode" \
               bash -c 'cat "$1" | opencode run --model "$2" 2>&1' _ "$prompt_file" "$model"
           else
+            # shellcheck disable=SC2016
             execute_with_timeout "$timeout" "OpenCode" \
               bash -c 'cat "$1" | opencode run 2>&1' _ "$prompt_file"
           fi

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -864,6 +864,7 @@ execute_provider_with_timeout() {
       fi
 
       execute_with_timeout "$timeout" "Ollama ($model)" execute_ollama "$model" "$prompt"
+      result=$?
       ;;
     lmstudio)
       local model="${provider#*:}"
@@ -878,11 +879,13 @@ execute_provider_with_timeout() {
       fi
 
       execute_with_timeout "$timeout" "LM Studio" execute_lmstudio "$model" "$prompt"
+      result=$?
       ;;
     *)
       # Generic fallback: wrap execute_provider with timeout
       # This ensures new providers added later still get timeout support
       execute_with_timeout "$timeout" "$base_provider" execute_provider "$provider" "$prompt"
+      result=$?
       ;;
   esac
 

--- a/spec/unit/providers_argmax_behavior_spec.sh
+++ b/spec/unit/providers_argmax_behavior_spec.sh
@@ -1,0 +1,116 @@
+# shellcheck shell=bash
+
+# Behavioral tests for ARG_MAX prompt handoff. These tests execute the timeout
+# wrapper with fake provider CLIs so we verify prompt bytes reach stdin instead
+# of only asserting command-string shape.
+
+Describe 'providers.sh ARG_MAX provider handoff behavior'
+  Include "$LIB_DIR/providers.sh"
+
+  setup() {
+    export CI=true
+    export GGA_NO_SPINNER=1
+    TEST_BIN_DIR="$(mktemp -d)"
+    ORIGINAL_PATH="$PATH"
+    PATH="$TEST_BIN_DIR:$PATH"
+
+    cat > "$TEST_BIN_DIR/claude" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" != "--print" ]]; then
+  echo "unexpected claude args: $*" >&2
+  exit 64
+fi
+cat
+FAKE
+
+    cat > "$TEST_BIN_DIR/gemini" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" != "-p" ]]; then
+  echo "unexpected gemini args: $*" >&2
+  exit 64
+fi
+cat
+FAKE
+
+    cat > "$TEST_BIN_DIR/codex" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" != "exec" || "$2" != "-" ]]; then
+  echo "unexpected codex args: $*" >&2
+  exit 64
+fi
+cat
+FAKE
+
+    cat > "$TEST_BIN_DIR/opencode" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" != "run" ]]; then
+  echo "unexpected opencode command: $*" >&2
+  exit 64
+fi
+shift
+if [[ "${1:-}" == "--model" ]]; then
+  echo "MODEL:$2"
+  shift 2
+fi
+if [[ $# -ne 0 ]]; then
+  echo "unexpected opencode positional prompt: $*" >&2
+  exit 64
+fi
+cat
+FAKE
+
+    chmod +x "$TEST_BIN_DIR/claude" "$TEST_BIN_DIR/gemini" "$TEST_BIN_DIR/codex" "$TEST_BIN_DIR/opencode"
+  }
+  BeforeEach 'setup'
+
+  cleanup() {
+    PATH="$ORIGINAL_PATH"
+    rm -rf "$TEST_BIN_DIR"
+    unset CI
+    unset GGA_NO_SPINNER
+    unset TEST_BIN_DIR
+    unset ORIGINAL_PATH
+  }
+  AfterEach 'cleanup'
+
+  It 'passes the full prompt to claude via stdin'
+    When call execute_provider_with_timeout "claude" $'line 1\nline 2' 5
+    The status should be success
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for Claude"
+  End
+
+  It 'passes the full prompt to gemini via stdin'
+    When call execute_provider_with_timeout "gemini" $'line 1\nline 2' 5
+    The status should be success
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for Gemini"
+  End
+
+  It 'passes the full prompt to codex via stdin'
+    When call execute_provider_with_timeout "codex" $'line 1\nline 2' 5
+    The status should be success
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for Codex"
+  End
+
+  It 'passes the full prompt to opencode via stdin without positional prompt args'
+    When call execute_provider_with_timeout "opencode" $'line 1\nline 2' 5
+    The status should be success
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for OpenCode"
+  End
+
+  It 'passes opencode model separately and prompt via stdin'
+    When call execute_provider_with_timeout "opencode:test-model" $'line 1\nline 2' 5
+    The status should be success
+    The output should include "MODEL:test-model"
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for OpenCode"
+  End
+End

--- a/spec/unit/providers_argmax_spec.sh
+++ b/spec/unit/providers_argmax_spec.sh
@@ -87,7 +87,7 @@ Describe 'providers.sh ARG_MAX handling'
       after_count=$(ls -1 "${TEMP}/gga_prompt."* 2>/dev/null | wc -l || echo 0)
 
       # Should be the same (temp file was cleaned up)
-      The value "$after_count" should eq "$before_count"
+      Assert [ "$after_count" -eq "$before_count" ]
       rm -rf "$test_temp"
     End
 
@@ -111,7 +111,7 @@ Describe 'providers.sh ARG_MAX handling'
       local after_count
       after_count=$(ls -1 "${TEMP}/gga_prompt."* 2>/dev/null | wc -l || echo 0)
 
-      The value "$after_count" should eq "$before_count"
+      Assert [ "$after_count" -eq "$before_count" ]
       # Exit code should be propagated
       The status should be failure
       rm -rf "$test_temp"

--- a/spec/unit/providers_argmax_spec.sh
+++ b/spec/unit/providers_argmax_spec.sh
@@ -1,0 +1,153 @@
+# shellcheck shell=bash
+
+# Tests for ARG_MAX fix - execute_provider_with_timeout should handle large prompts
+# via temp files for CLI providers (claude, gemini, codex, opencode).
+# Related issues: #77 (macOS), #87 (Windows), #58, #85
+
+Describe 'providers.sh ARG_MAX handling'
+  Include "$LIB_DIR/providers.sh"
+
+  Describe 'execute_provider_with_timeout() - temp file for CLI providers'
+    # Mock execute_with_timeout to capture how it's called
+    execute_with_timeout() {
+      local timeout="$1"
+      local provider_name="$2"
+      shift 2
+      # Capture the command that would be executed
+      echo "TIMEOUT:$timeout:$provider_name"
+      echo "CMD:$*"
+      # Simulate success
+      return 0
+    }
+
+    # Mock provider commands
+    claude() { cat; }
+    codex() { cat; }
+    opencode() { cat; }
+    gemini() { cat; }
+
+    It 'writes prompt to temp file for claude'
+      When call execute_provider_with_timeout "claude" "test prompt" 300
+      The output should include "TIMEOUT:300:Claude"
+      # The command should use bash -c with cat to read from temp file
+      The output should include "bash -c"
+      The output should include "cat"
+    End
+
+    It 'writes prompt to temp file for codex'
+      When call execute_provider_with_timeout "codex" "test prompt" 300
+      The output should include "TIMEOUT:300:Codex"
+      The output should include "bash -c"
+    End
+
+    It 'writes prompt to temp file for opencode without model'
+      When call execute_provider_with_timeout "opencode" "test prompt" 300
+      The output should include "TIMEOUT:300:OpenCode"
+      The output should include "bash -c"
+      # opencode run without positional args reads from stdin
+      The output should include "opencode run"
+    End
+
+    It 'writes prompt to temp file for opencode with model'
+      When call execute_provider_with_timeout "opencode:gpt-4" "test prompt" 300
+      The output should include "TIMEOUT:300:OpenCode"
+      The output should include "bash -c"
+      The output should include "opencode run --model"
+    End
+
+    It 'writes prompt to temp file for gemini'
+      When call execute_provider_with_timeout "gemini" "test prompt" 300
+      The output should include "TIMEOUT:300:Gemini"
+      The output should include "bash -c"
+      The output should include "gemini -p -"
+    End
+
+    It 'handles large prompts without ARG_MAX errors'
+      local large_prompt
+      large_prompt=$(printf 'x%.0s' {1..400000})  # 400KB > ARG_MAX
+      # This should not fail with "Argument list too long"
+      When call execute_provider_with_timeout "claude" "$large_prompt" 300
+      The output should include "TIMEOUT:300:Claude"
+      The status should be success
+    End
+
+    It 'cleans up temp file after execution'
+      local test_temp
+      test_temp="$(mktemp -d)"
+      TEMP="$test_temp"
+
+      # Count temp files before
+      local before_count
+      before_count=$(ls -1 "${TEMP}/gga_prompt."* 2>/dev/null | wc -l || echo 0)
+
+      When call execute_provider_with_timeout "claude" "test prompt" 300
+
+      # Count temp files after
+      local after_count
+      after_count=$(ls -1 "${TEMP}/gga_prompt."* 2>/dev/null | wc -l || echo 0)
+
+      # Should be the same (temp file was cleaned up)
+      The value "$after_count" should eq "$before_count"
+      rm -rf "$test_temp"
+    End
+
+    It 'cleans up temp file even on error'
+      local test_temp
+      test_temp="$(mktemp -d)"
+      TEMP="$test_temp"
+
+      # Mock execute_with_timeout to fail
+      execute_with_timeout() {
+        return 1
+      }
+
+      # Count temp files before
+      local before_count
+      before_count=$(ls -1 "${TEMP}/gga_prompt."* 2>/dev/null | wc -l || echo 0)
+
+      When call execute_provider_with_timeout "claude" "test prompt" 300
+
+      # Count temp files after - should still be cleaned up
+      local after_count
+      after_count=$(ls -1 "${TEMP}/gga_prompt."* 2>/dev/null | wc -l || echo 0)
+
+      The value "$after_count" should eq "$before_count"
+      rm -rf "$test_temp"
+    End
+
+    It 'passes model as positional argument to avoid shell injection'
+      # Model with special characters should be passed safely as $2
+      When call execute_provider_with_timeout "opencode:model-with-\$pecial-chars" "test prompt" 300
+      The output should include "TIMEOUT:300:OpenCode"
+      The output should include "bash -c"
+      # The model should be passed as a separate argument, not interpolated in bash -c string
+      The output should include "opencode run --model"
+    End
+  End
+
+  Describe 'execute_provider_with_timeout() - API providers unchanged'
+    # API-based providers (ollama, lmstudio) don't need temp files
+    # because they use curl/HTTP and don't have argv limits
+
+    It 'does not use temp file for ollama'
+      # Mock execute_ollama to capture it was called directly
+      execute_ollama() {
+        echo "OLLAMA_CALLED:$1:$2"
+      }
+      validate_ollama_host() { return 0; }
+
+      When call execute_provider_with_timeout "ollama:llama3" "test prompt" 300
+      The output should include "OLLAMA_CALLED:llama3:test prompt"
+    End
+
+    It 'does not use temp file for lmstudio'
+      execute_lmstudio() {
+        echo "LMSTUDIO_CALLED:$1:$2"
+      }
+      validate_lmstudio_host() { return 0; }
+
+      When call execute_provider_with_timeout "lmstudio:llama-3" "test prompt" 300
+      The output should include "LMSTUDIO_CALLED:llama-3:test prompt"
+    End
+  End
+End

--- a/spec/unit/providers_argmax_spec.sh
+++ b/spec/unit/providers_argmax_spec.sh
@@ -112,6 +112,8 @@ Describe 'providers.sh ARG_MAX handling'
       after_count=$(ls -1 "${TEMP}/gga_prompt."* 2>/dev/null | wc -l || echo 0)
 
       The value "$after_count" should eq "$before_count"
+      # Exit code should be propagated
+      The status should be failure
       rm -rf "$test_temp"
     End
 
@@ -148,6 +150,47 @@ Describe 'providers.sh ARG_MAX handling'
 
       When call execute_provider_with_timeout "lmstudio:llama-3" "test prompt" 300
       The output should include "LMSTUDIO_CALLED:llama-3:test prompt"
+    End
+
+    It 'propagates exit code for ollama'
+      # Mock execute_with_timeout to fail
+      execute_with_timeout() {
+        return 42
+      }
+      execute_ollama() {
+        echo "OLLAMA_CALLED"
+      }
+      validate_ollama_host() { return 0; }
+
+      When call execute_provider_with_timeout "ollama:llama3" "test prompt" 300
+      The status should eq 42
+    End
+
+    It 'propagates exit code for lmstudio'
+      # Mock execute_with_timeout to fail
+      execute_with_timeout() {
+        return 42
+      }
+      execute_lmstudio() {
+        echo "LMSTUDIO_CALLED"
+      }
+      validate_lmstudio_host() { return 0; }
+
+      When call execute_provider_with_timeout "lmstudio:llama-3" "test prompt" 300
+      The status should eq 42
+    End
+
+    It 'propagates exit code for generic fallback'
+      # Mock execute_with_timeout to fail
+      execute_with_timeout() {
+        return 42
+      }
+      execute_provider() {
+        echo "FALLBACK_CALLED"
+      }
+
+      When call execute_provider_with_timeout "unknown-provider" "test prompt" 300
+      The status should eq 42
     End
   End
 End

--- a/spec/unit/providers_argmax_spec.sh
+++ b/spec/unit/providers_argmax_spec.sh
@@ -29,9 +29,10 @@ Describe 'providers.sh ARG_MAX handling'
     It 'writes prompt to temp file for claude'
       When call execute_provider_with_timeout "claude" "test prompt" 300
       The output should include "TIMEOUT:300:Claude"
-      # The command should use bash -c with cat to read from temp file
+      # The command should use bash -c with exec and input redirection so the
+      # timeout watcher owns the provider process, not an intermediate pipeline.
       The output should include "bash -c"
-      The output should include "cat"
+      The output should include "exec claude --print"
     End
 
     It 'writes prompt to temp file for codex'
@@ -59,7 +60,7 @@ Describe 'providers.sh ARG_MAX handling'
       When call execute_provider_with_timeout "gemini" "test prompt" 300
       The output should include "TIMEOUT:300:Gemini"
       The output should include "bash -c"
-      The output should include "gemini -p -"
+      The output should include "exec gemini -p"
     End
 
     It 'handles large prompts without ARG_MAX errors'
@@ -125,6 +126,17 @@ Describe 'providers.sh ARG_MAX handling'
       The output should include "bash -c"
       # The model should be passed as a separate argument, not interpolated in bash -c string
       The output should include "opencode run --model"
+    End
+
+    It 'fails safely when temp file creation fails'
+      local original_temp="${TEMP:-}"
+      TEMP="/definitely/missing/gga"
+
+      When call execute_provider_with_timeout "claude" "test prompt" 300
+
+      The status should be failure
+      The stderr should include "Failed to create temporary prompt file"
+      TEMP="$original_temp"
     End
   End
 

--- a/spec/unit/providers_argmax_spec.sh
+++ b/spec/unit/providers_argmax_spec.sh
@@ -88,6 +88,7 @@ Describe 'providers.sh ARG_MAX handling'
 
       # Should be the same (temp file was cleaned up)
       Assert [ "$after_count" -eq "$before_count" ]
+      The output should include "TIMEOUT:300:Claude"
       rm -rf "$test_temp"
     End
 
@@ -128,11 +129,17 @@ Describe 'providers.sh ARG_MAX handling'
   End
 
   Describe 'execute_provider_with_timeout() - API providers unchanged'
-    # API-based providers (ollama, lmstudio) don't need temp files
-    # because they use curl/HTTP and don't have argv limits
+    # API-based providers (ollama, lmstudio) are intentionally left on their
+    # existing execution path in this PR. Their prompt transport is covered by
+    # separate API-provider tests/issues.
 
     It 'does not use temp file for ollama'
-      # Mock execute_ollama to capture it was called directly
+      # Mock execute_with_timeout to avoid progress output warnings and execute
+      # the wrapped provider command directly.
+      execute_with_timeout() {
+        shift 2
+        "$@"
+      }
       execute_ollama() {
         echo "OLLAMA_CALLED:$1:$2"
       }
@@ -143,6 +150,10 @@ Describe 'providers.sh ARG_MAX handling'
     End
 
     It 'does not use temp file for lmstudio'
+      execute_with_timeout() {
+        shift 2
+        "$@"
+      }
       execute_lmstudio() {
         echo "LMSTUDIO_CALLED:$1:$2"
       }


### PR DESCRIPTION
## Summary

Refactors `execute_provider_with_timeout()` to use a temp file + stdin pipe approach for CLI providers, fixing ARG_MAX errors on Windows/macOS/Linux with large PRs.

This PR supersedes #88 with a cleaner, more scalable solution.

## Problem

The original code passed prompts as command-line arguments, hitting OS ARG_MAX limits:
- Windows cmd.exe: ~8KB
- Windows Git Bash: ~32KB  
- macOS: ~256KB
- Linux: ~128KB-2MB

When reviewing PRs with 20+ files, the prompt exceeds these limits and fails with `Argument list too long`.

## Solution

**Design principles:**
1. **Single temp file creation** - Create once in `execute_provider_with_timeout()`, not duplicated in each provider function
2. **Pass only file path** - Only the ~50 char path goes into argv, never the prompt content
3. **Guaranteed cleanup** - `trap RETURN` ensures cleanup on success, error, or signal
4. **Shell injection safe** - Model passed as positional arg `$2`, not interpolated in `bash -c` string
5. **Correct stdin handling** - `opencode run` without `-` (reads stdin automatically when no positional args)

**Implementation:**
```bash
# Write prompt to temp file ONCE
prompt_file=$(mktemp)
printf '%s' "$prompt" > "$prompt_file"
trap 'rm -f "$prompt_file"' RETURN

# Pass only file path as argument
bash -c 'cat "$1" | opencode run --model "$2" 2>&1' _ "$prompt_file" "$model"

# Cleanup (also handled by trap)
rm -f "$prompt_file"
```

## Changes

- **`lib/providers.sh`**: Refactored `execute_provider_with_timeout()` to use temp file + stdin for CLI providers (claude, gemini, codex, opencode)
- **`spec/unit/providers_argmax_spec.sh`**: Added comprehensive tests for ARG_MAX handling

## Why this approach?

**vs PR #88:**
- PR #88 uses `opencode run -` which doesn't work (opencode doesn't support explicit `-` flag)
- PR #88 has duplicated temp file logic in multiple functions
- This PR has single point of creation, cleaner separation of concerns

**vs alternatives:**
- Named pipes: More complex, not portable to Windows
- `xargs`: Doesn't help with single-command execution
- Chunking: Breaks prompt semantics

## Testing

Added tests verify:
- Temp file creation for each CLI provider
- Large prompt handling (400KB > ARG_MAX)
- Cleanup on success and error
- Shell injection prevention
- API providers (ollama, lmstudio) unchanged

Fixes #87, #85, #78, #77, #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved large-prompt execution for CLI-based AI providers by routing prompts through a safer input mechanism, preventing “Argument list too long” errors.
  * Refined exit-code and timeout handling across CLI, non-CLI, and unknown provider paths, with reliable temporary prompt cleanup even on failures.

* **Tests**
  * Added unit tests covering large prompts, temporary prompt file lifecycle (success and forced cleanup), provider-specific invocation variations (including model string edge cases), and correct behavior for unknown/non-CLI providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->