### PR TITLE
fix(providers): usar archivo temporal en Claude para evitar ARG_MAX en revisiones grandes

### DIFF
--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -802,7 +802,9 @@ execute_provider_with_timeout() {
       printf '%s' "$prompt" > "$_claude_tmpfile"
       execute_with_timeout "$timeout" "Claude" \
         bash -c 'claude --print 2>&1 < "$1"' -- "$_claude_tmpfile"
+      local _claude_status=$?
       rm -f "$_claude_tmpfile"
+      return $_claude_status
       ;;
     gemini)
       execute_with_timeout "$timeout" "Gemini" gemini -p "$prompt"

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -801,7 +801,8 @@ execute_provider_with_timeout() {
       _claude_tmpfile=$(mktemp) || { echo "gga: mktemp failed" >&2; return 1; }
       printf '%s' "$prompt" > "$_claude_tmpfile"
       execute_with_timeout "$timeout" "Claude" \
-        bash -c 'claude --print 2>&1 < "$1"; rm -f "$1"' -- "$_claude_tmpfile"
+        bash -c 'claude --print 2>&1 < "$1"' -- "$_claude_tmpfile"
+      rm -f "$_claude_tmpfile"
       ;;
     gemini)
       execute_with_timeout "$timeout" "Gemini" gemini -p "$prompt"

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -804,7 +804,7 @@ execute_provider_with_timeout() {
         bash -c 'claude --print 2>&1 < "$1"' -- "$_claude_tmpfile"
       local _claude_status=$?
       rm -f "$_claude_tmpfile"
-      return $_claude_status
+      return "$_claude_status"
       ;;
     gemini)
       execute_with_timeout "$timeout" "Gemini" gemini -p "$prompt"

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -793,7 +793,15 @@ execute_provider_with_timeout() {
 
   case "$base_provider" in
     claude)
-      execute_with_timeout "$timeout" "Claude" bash -c "printf '%s' \"\$1\" | claude --print 2>&1" -- "$prompt"
+      # Write prompt to a temp file to avoid ARG_MAX limits when the review
+      # payload is large. Passing $prompt as a bash argv ($1) fails on Linux
+      # (~2 MB ARG_MAX) and macOS when staged files are large.
+      # See: https://github.com/Gentleman-Programming/gentleman-guardian-angel/issues/78
+      local _claude_tmpfile
+      _claude_tmpfile=$(mktemp) || { echo "gga: mktemp failed" >&2; return 1; }
+      printf '%s' "$prompt" > "$_claude_tmpfile"
+      execute_with_timeout "$timeout" "Claude" \
+        bash -c 'claude --print 2>&1 < "$1"; rm -f "$1"' -- "$_claude_tmpfile"
       ;;
     gemini)
       execute_with_timeout "$timeout" "Gemini" gemini -p "$prompt"

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -798,7 +798,7 @@ execute_provider_with_timeout() {
       # (~2 MB ARG_MAX) and macOS when staged files are large.
       # See: https://github.com/Gentleman-Programming/gentleman-guardian-angel/issues/78
       local _claude_tmpfile
-      _claude_tmpfile=$(mktemp) || { echo "gga: mktemp failed" >&2; return 1; }
+      _claude_tmpfile=$(mktemp "${TEMP:-${TMPDIR:-/tmp}}/gga_claude_XXXXXX") || { echo "gga: mktemp failed" >&2; return 1; }
       printf '%s' "$prompt" > "$_claude_tmpfile"
       execute_with_timeout "$timeout" "Claude" \
         bash -c 'claude --print 2>&1 < "$1"' -- "$_claude_tmpfile"


### PR DESCRIPTION
## Problema

El proveedor Claude en `execute_provider_with_timeout` (línea 796) pasa el prompt completo como argumento posicional de bash (`$1`):

```bash
execute_with_timeout "$timeout" "Claude" bash -c "printf '%s' \"$1\" | claude --print 2>&1" -- "$prompt"
```

Cuando los archivos staged son grandes, el prompt combinado (reglas + contenido de archivos) supera **ARG_MAX** (~2 MB en Linux), causando:

```
/usr/bin/bash: Argument list too long  (exit 126)
```

Esto fuerza a los equipos a hacer commits con `--no-verify`, anulando la revisión.

## Por qué esto es distinto de lo reportado en #78 / #85

El comentario en #78 afirma que *"execute_claude ya usa stdin"* — lo cual es **parcialmente correcto pero no para el code path con timeout**.

- `execute_claude()` (línea ~217) ✅ usa `printf '%s' "$prompt" | claude --print` — seguro.
- `execute_provider_with_timeout()` (línea 796) ❌ inlinea un `bash -c "..."` diferente que pasa `$prompt` como `$1` al proceso bash — esto sí golpea ARG_MAX.

Los dos code paths existen en paralelo. El bug solo aparece cuando hay timeout activo (el path normal).

## Fix

Escribir el prompt a un archivo `mktemp` y pasar solo la ruta como `$1`. `claude --print` lee desde stdin (redirección de archivo), sin necesidad de argv. El archivo temporal se elimina dentro del subshell.

```bash
claude)
  local _claude_tmpfile
  _claude_tmpfile=$(mktemp) || { echo "gga: mktemp failed" >&2; return 1; }
  printf '%s' "$prompt" > "$_claude_tmpfile"
  execute_with_timeout "$timeout" "Claude" \
    bash -c 'claude --print 2>&1 < "$1"; rm -f "$1"' -- "$_claude_tmpfile"
  ;;
```

Este patrón es consistente con el comentario `# Using stdin to avoid ARG_MAX limits` ya presente en `execute_lmstudio()`.

## Probado en

- **OS**: Ubuntu 24.04 LTS (Linux)
- **Shell**: zsh / bash
- **GGA**: v2.8.1
- **Proveedor**: `claude` (Claude Code CLI)
- **Caso**: commit con 4 archivos staged incluyendo un playbook Ansible de 1000+ líneas — antes fallaba con exit 126, ahora completa la revisión correctamente.

## Alcance del diff

+8 líneas / -1 línea. Solo afecta el `case claude)` en `execute_provider_with_timeout`.

---

*Reportado por Pablo Tapia — OpenBox Informática Chile, usando gentle-ai en infraestructura EAS (Docker Swarm, 26 stacks modulares). Agradecemos el trabajo del equipo Gentleman-Programming.*

Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt delivery reliability for Claude by switching to a more robust stdin approach.
  * Added explicit handling for temporary file creation failures, including clearer error messaging and safer failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->