### PR TITLE
feat(providers): add OpenCode variant and agent options

### DIFF
--- a/bin/gga
+++ b/bin/gga
@@ -162,6 +162,8 @@ print_help() {
   echo "  STRICT_MODE        Fail on ambiguous AI response (default: true)"
   echo "  TIMEOUT            Max seconds to wait for AI response (default: 300)"
   echo "  PR_BASE_BRANCH     Base branch for --pr-mode (default: auto-detect)"
+  echo "  OPENCODE_VARIANT   OpenCode reasoning effort/variant (default: unset)"
+  echo "  OPENCODE_AGENT     OpenCode agent profile (default: unset)"
   echo ""
   echo -e "${BOLD}EXAMPLES:${NC}"
   echo "  gga init               # Create sample config"
@@ -175,8 +177,10 @@ print_help() {
   echo "  gga cache status       # Show cache info"
   echo ""
   echo -e "${BOLD}ENVIRONMENT VARIABLES:${NC}"
-  echo "  GGA_PROVIDER      Override provider from config"
-  echo "  GGA_TIMEOUT       Override timeout from config (seconds)"
+  echo "  GGA_PROVIDER          Override provider from config"
+  echo "  GGA_TIMEOUT           Override timeout from config (seconds)"
+  echo "  GGA_OPENCODE_VARIANT  Override OPENCODE_VARIANT from config"
+  echo "  GGA_OPENCODE_AGENT    Override OPENCODE_AGENT from config"
   echo ""
 }
 
@@ -214,6 +218,8 @@ load_config() {
   STRICT_MODE="$DEFAULT_STRICT_MODE"
   TIMEOUT="$DEFAULT_TIMEOUT"
   PR_BASE_BRANCH=""
+  OPENCODE_VARIANT=""
+  OPENCODE_AGENT=""
 
   # Load global config first (platform-aware path)
   if [[ -n "${APPDATA:-}" ]]; then
@@ -241,6 +247,12 @@ load_config() {
   fi
   if [[ -n "${GGA_TIMEOUT:-}" ]]; then
     TIMEOUT="$GGA_TIMEOUT"
+  fi
+  if [[ -n "${GGA_OPENCODE_VARIANT:-}" ]]; then
+    OPENCODE_VARIANT="$GGA_OPENCODE_VARIANT"
+  fi
+  if [[ -n "${GGA_OPENCODE_AGENT:-}" ]]; then
+    OPENCODE_AGENT="$GGA_OPENCODE_AGENT"
   fi
 }
 
@@ -294,6 +306,16 @@ cmd_config() {
   echo -e "  RULES_FILE:        ${CYAN}$RULES_FILE${NC}"
   echo -e "  STRICT_MODE:       ${CYAN}$STRICT_MODE${NC}"
   echo -e "  TIMEOUT:           ${CYAN}${TIMEOUT}s${NC}"
+  if [[ -n "${OPENCODE_VARIANT:-}" ]]; then
+    echo -e "  OPENCODE_VARIANT:  ${CYAN}$OPENCODE_VARIANT${NC}"
+  else
+    echo -e "  OPENCODE_VARIANT:  ${YELLOW}Not set${NC}"
+  fi
+  if [[ -n "${OPENCODE_AGENT:-}" ]]; then
+    echo -e "  OPENCODE_AGENT:    ${CYAN}$OPENCODE_AGENT${NC}"
+  else
+    echo -e "  OPENCODE_AGENT:    ${YELLOW}Not set${NC}"
+  fi
   if [[ -n "${PR_BASE_BRANCH:-}" ]]; then
     echo -e "  PR_BASE_BRANCH:    ${CYAN}$PR_BASE_BRANCH${NC}"
   else
@@ -371,6 +393,14 @@ STRICT_MODE="true"
 # Default: 300 (5 minutes)
 # Increase for large changesets or slow connections
 TIMEOUT="300"
+
+# OpenCode provider: optional reasoning effort / variant
+# Examples: minimal, low, medium, high, max
+# OPENCODE_VARIANT="high"
+
+# OpenCode provider: optional agent profile
+# Keep this lightweight. Agent prompts can add significant token overhead.
+# OPENCODE_AGENT="gga-reviewer"
 
 # Base branch for --pr-mode (auto-detects main/master/develop if empty)
 # Default: auto-detect

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -268,16 +268,33 @@ execute_codex() {
   return "$codex_status"
 }
 
+get_opencode_option_args() {
+  local variant="${GGA_OPENCODE_VARIANT:-${OPENCODE_VARIANT:-}}"
+  local agent="${GGA_OPENCODE_AGENT:-${OPENCODE_AGENT:-}}"
+
+  if [[ -n "$variant" ]]; then
+    printf '%s\n' "--variant" "$variant"
+  fi
+  if [[ -n "$agent" ]]; then
+    printf '%s\n' "--agent" "$agent"
+  fi
+}
+
 execute_opencode() {
   local model="$1"
   local prompt="$2"
-  
-  # OpenCode CLI accepts prompt as positional argument
-  # opencode run [message..] - message is a positional array
+  local opencode_args=()
+
+  while IFS= read -r arg; do
+    opencode_args+=("$arg")
+  done < <(get_opencode_option_args)
+
+  # OpenCode CLI accepts prompt as positional argument.
+  # The timeout path uses stdin to avoid ARG_MAX for normal GGA runs.
   if [[ -n "$model" ]]; then
-    opencode run --model "$model" "$prompt" 2>&1
+    opencode run --model "$model" "${opencode_args[@]}" -- "$prompt" 2>&1
   else
-    opencode run "$prompt" 2>&1
+    opencode run "${opencode_args[@]}" -- "$prompt" 2>&1
   fi
   return $?
 }
@@ -648,10 +665,25 @@ get_provider_info() {
       ;;
     opencode)
       local model="${provider#*:}"
-      if [[ "$model" == "$provider" ]]; then
+      local variant="${GGA_OPENCODE_VARIANT:-${OPENCODE_VARIANT:-}}"
+      local agent="${GGA_OPENCODE_AGENT:-${OPENCODE_AGENT:-}}"
+      local details=()
+
+      if [[ "$model" != "$provider" ]]; then
+        details+=("model: $model")
+      fi
+      if [[ -n "$variant" ]]; then
+        details+=("variant: $variant")
+      fi
+      if [[ -n "$agent" ]]; then
+        details+=("agent: $agent")
+      fi
+
+      if [[ ${#details[@]} -eq 0 ]]; then
         echo "OpenCode CLI"
       else
-        echo "OpenCode CLI (model: $model)"
+        local IFS=', '
+        echo "OpenCode CLI (${details[*]})"
       fi
       ;;
     ollama)
@@ -870,20 +902,25 @@ execute_provider_with_timeout() {
           ;;
         opencode)
           local model="${provider#*:}"
+          local opencode_args=()
           if [[ "$model" == "$provider" ]]; then
             model=""
           fi
+          while IFS= read -r arg; do
+            opencode_args+=("$arg")
+          done < <(get_opencode_option_args)
+
           if [[ -n "$model" ]]; then
-            # Pass model as $2 to avoid shell injection (not interpolated in bash -c string).
+            # Pass model and option args positionally to avoid shell injection.
             # opencode run (without positional message args) reads from stdin automatically.
             # NOTE: Do NOT use '-' as opencode doesn't support explicit stdin flag.
             # shellcheck disable=SC2016
             execute_with_timeout "$timeout" "OpenCode" \
-              bash -c 'exec opencode run --model "$2" < "$1"' _ "$prompt_file" "$model"
+              bash -c 'exec opencode run --model "$2" "${@:3}" < "$1"' _ "$prompt_file" "$model" "${opencode_args[@]}"
           else
             # shellcheck disable=SC2016
             execute_with_timeout "$timeout" "OpenCode" \
-              bash -c 'exec opencode run < "$1"' _ "$prompt_file"
+              bash -c 'exec opencode run "${@:2}" < "$1"' _ "$prompt_file" "${opencode_args[@]}"
           fi
           result=$?
           ;;

--- a/spec/integration/commands_spec.sh
+++ b/spec/integration/commands_spec.sh
@@ -113,12 +113,44 @@ Describe 'gga commands'
   Describe 'gga config'
     setup() {
       TEMP_DIR=$(mktemp -d)
+      TEST_HOME=$(mktemp -d)
+      ORIGINAL_HOME="${HOME:-}"
+      ORIGINAL_XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-}"
+      ORIGINAL_APPDATA="${APPDATA:-}"
+      ORIGINAL_GGA_OPENCODE_VARIANT="${GGA_OPENCODE_VARIANT:-}"
+      ORIGINAL_GGA_OPENCODE_AGENT="${GGA_OPENCODE_AGENT:-}"
+      HOME="$TEST_HOME"
+      XDG_CONFIG_HOME="$TEST_HOME/.config"
+      unset APPDATA
+      unset GGA_OPENCODE_VARIANT
+      unset GGA_OPENCODE_AGENT
       cd "$TEMP_DIR"
     }
 
     cleanup() {
       cd /
-      rm -rf "$TEMP_DIR"
+      HOME="$ORIGINAL_HOME"
+      if [[ -n "$ORIGINAL_XDG_CONFIG_HOME" ]]; then
+        XDG_CONFIG_HOME="$ORIGINAL_XDG_CONFIG_HOME"
+      else
+        unset XDG_CONFIG_HOME
+      fi
+      if [[ -n "$ORIGINAL_APPDATA" ]]; then
+        APPDATA="$ORIGINAL_APPDATA"
+      else
+        unset APPDATA
+      fi
+      if [[ -n "$ORIGINAL_GGA_OPENCODE_VARIANT" ]]; then
+        GGA_OPENCODE_VARIANT="$ORIGINAL_GGA_OPENCODE_VARIANT"
+      else
+        unset GGA_OPENCODE_VARIANT
+      fi
+      if [[ -n "$ORIGINAL_GGA_OPENCODE_AGENT" ]]; then
+        GGA_OPENCODE_AGENT="$ORIGINAL_GGA_OPENCODE_AGENT"
+      else
+        unset GGA_OPENCODE_AGENT
+      fi
+      rm -rf "$TEMP_DIR" "$TEST_HOME"
     }
 
     BeforeEach 'setup'
@@ -139,6 +171,32 @@ Describe 'gga commands'
       echo 'PROVIDER="claude"' > .gga
       When call gga config
       The output should include "claude"
+    End
+
+    It 'shows OpenCode variant and agent when configured'
+      cat > .gga <<'EOF'
+PROVIDER="opencode"
+OPENCODE_VARIANT="high"
+OPENCODE_AGENT="gga-reviewer"
+EOF
+      When call gga config
+      The output should include "OPENCODE_VARIANT"
+      The output should include "high"
+      The output should include "OPENCODE_AGENT"
+      The output should include "gga-reviewer"
+    End
+
+    It 'lets GGA-prefixed OpenCode environment variables override config'
+      cat > .gga <<'EOF'
+PROVIDER="opencode"
+OPENCODE_VARIANT="low"
+OPENCODE_AGENT="default-agent"
+EOF
+      When call env GGA_OPENCODE_VARIANT=max GGA_OPENCODE_AGENT=override-agent "$PROJECT_ROOT/bin/gga" config
+      The output should include "max"
+      The output should include "override-agent"
+      The output should not include "low"
+      The output should not include "default-agent"
     End
 
     It 'shows rules file status'

--- a/spec/unit/providers_argmax_behavior_spec.sh
+++ b/spec/unit/providers_argmax_behavior_spec.sh
@@ -52,10 +52,22 @@ if [[ "${1:-}" == "--model" ]]; then
   echo "MODEL:$2"
   shift 2
 fi
-if [[ $# -ne 0 ]]; then
-  echo "unexpected opencode positional prompt: $*" >&2
-  exit 64
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --variant)
+      echo "VARIANT:$2"
+      shift 2
+      ;;
+    --agent)
+      echo "AGENT:$2"
+      shift 2
+      ;;
+    *)
+      echo "unexpected opencode positional prompt: $*" >&2
+      exit 64
+      ;;
+  esac
+done
 cat
 FAKE
 
@@ -70,6 +82,7 @@ FAKE
     unset GGA_NO_SPINNER
     unset TEST_BIN_DIR
     unset ORIGINAL_PATH
+    unset OPENCODE_VARIANT GGA_OPENCODE_VARIANT OPENCODE_AGENT GGA_OPENCODE_AGENT
   }
   AfterEach 'cleanup'
 
@@ -111,6 +124,38 @@ FAKE
     The output should include "MODEL:test-model"
     The output should include "line 1"
     The output should include "line 2"
+    The stderr should include "Waiting for OpenCode"
+  End
+
+  It 'passes opencode variant and agent flags while keeping prompt on stdin'
+    OPENCODE_VARIANT="high"
+    OPENCODE_AGENT="gga-reviewer"
+
+    When call execute_provider_with_timeout "opencode:test-model" $'line 1\nline 2' 5
+
+    The status should be success
+    The output should include "MODEL:test-model"
+    The output should include "VARIANT:high"
+    The output should include "AGENT:gga-reviewer"
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for OpenCode"
+  End
+
+  It 'prefers GGA-prefixed opencode flag overrides with stdin handoff'
+    OPENCODE_VARIANT="low"
+    GGA_OPENCODE_VARIANT="max"
+    OPENCODE_AGENT="default-agent"
+    GGA_OPENCODE_AGENT="override-agent"
+
+    When call execute_provider_with_timeout "opencode" "test prompt" 5
+
+    The status should be success
+    The output should include "VARIANT:max"
+    The output should include "AGENT:override-agent"
+    The output should include "test prompt"
+    The output should not include "VARIANT:low"
+    The output should not include "AGENT:default-agent"
     The stderr should include "Waiting for OpenCode"
   End
 End

--- a/spec/unit/providers_opencode_spec.sh
+++ b/spec/unit/providers_opencode_spec.sh
@@ -14,6 +14,33 @@ Describe 'providers.sh opencode support'
       The output should include "OpenCode"
       The output should include "model: gpt-4"
     End
+
+    It 'returns info with OpenCode variant and agent'
+      OPENCODE_VARIANT="high"
+      OPENCODE_AGENT="gga-reviewer"
+
+      When call get_provider_info "opencode:gpt-4"
+
+      The output should include "model: gpt-4"
+      The output should include "variant: high"
+      The output should include "agent: gga-reviewer"
+      unset OPENCODE_VARIANT OPENCODE_AGENT
+    End
+
+    It 'prefers GGA-prefixed OpenCode overrides in provider info'
+      OPENCODE_VARIANT="low"
+      GGA_OPENCODE_VARIANT="max"
+      OPENCODE_AGENT="default-agent"
+      GGA_OPENCODE_AGENT="override-agent"
+
+      When call get_provider_info "opencode"
+
+      The output should include "variant: max"
+      The output should include "agent: override-agent"
+      The output should not include "variant: low"
+      The output should not include "agent: default-agent"
+      unset OPENCODE_VARIANT GGA_OPENCODE_VARIANT OPENCODE_AGENT GGA_OPENCODE_AGENT
+    End
   End
 
   Describe 'execute_opencode()'
@@ -25,11 +52,29 @@ Describe 'providers.sh opencode support'
            local model="$2"
            shift 2 # remove "--model" and model name
            echo "Run with model: $model"
-           echo "$*" # echo the prompt (remaining args)
         else
            echo "Run default"
-           echo "$*" # echo the prompt (remaining args)
         fi
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --variant)
+              echo "Variant: $2"
+              shift 2
+              ;;
+            --agent)
+              echo "Agent: $2"
+              shift 2
+              ;;
+            --)
+              shift
+              break
+              ;;
+            *)
+              break
+              ;;
+          esac
+        done
+        echo "$*" # echo the prompt (remaining args)
       fi
     }
 
@@ -43,6 +88,34 @@ Describe 'providers.sh opencode support'
       When call execute_opencode "gpt-4" "test prompt"
       The output should include "Run with model: gpt-4"
       The output should include "test prompt"
+    End
+
+    It 'passes OpenCode variant and agent flags'
+      OPENCODE_VARIANT="high"
+      OPENCODE_AGENT="gga-reviewer"
+
+      When call execute_opencode "gpt-4" "test prompt"
+
+      The output should include "Run with model: gpt-4"
+      The output should include "Variant: high"
+      The output should include "Agent: gga-reviewer"
+      The output should include "test prompt"
+      unset OPENCODE_VARIANT OPENCODE_AGENT
+    End
+
+    It 'prefers GGA-prefixed OpenCode flag overrides'
+      OPENCODE_VARIANT="low"
+      GGA_OPENCODE_VARIANT="max"
+      OPENCODE_AGENT="default-agent"
+      GGA_OPENCODE_AGENT="override-agent"
+
+      When call execute_opencode "" "test prompt"
+
+      The output should include "Variant: max"
+      The output should include "Agent: override-agent"
+      The output should not include "Variant: low"
+      The output should not include "Agent: default-agent"
+      unset OPENCODE_VARIANT GGA_OPENCODE_VARIANT OPENCODE_AGENT GGA_OPENCODE_AGENT
     End
   End
 


### PR DESCRIPTION
## Summary
Add optional OpenCode provider knobs for reasoning variant and agent profile while preserving the ARG_MAX-safe stdin handoff used by normal GGA runs.

## Changes
- Add `OPENCODE_VARIANT` / `GGA_OPENCODE_VARIANT` support for `opencode run --variant`
- Add `OPENCODE_AGENT` / `GGA_OPENCODE_AGENT` support for `opencode run --agent`
- Show these settings in `gga config`, `gga help`, and generated `.gga`
- Add unit and integration coverage for config/env precedence and timeout stdin behavior
- Isolate `gga config` integration tests from developer global config

## Testing
- `shellspec spec/unit/providers_opencode_spec.sh spec/unit/providers_argmax_behavior_spec.sh spec/integration/commands_spec.sh`
- `GGA_OPENCODE_VARIANT=external GGA_OPENCODE_AGENT=external-agent shellspec spec/integration/commands_spec.sh:146`
- `make lint`

Closes #79
