### PR TITLE
feat(providers): add Cursor Agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <strong>Provider-agnostic code review using AI</strong><br>
-  Use Claude, Gemini, Codex, OpenCode, Ollama, LM Studio, GitHub Models, or any AI to enforce your coding standards.<br>
+  Use Claude, Gemini, Codex, OpenCode, Cursor Agent, Ollama, LM Studio, GitHub Models, or any AI to enforce your coding standards.<br>
   Zero dependencies. Pure Bash. Works everywhere.
 </p>
 
@@ -45,7 +45,7 @@ You have coding standards. Your team ignores them. Code reviews catch issues too
 └─────────────────┘     └──────────────┘     └─────────────────┘
 ```
 
-- 🔌 **Provider agnostic** — Claude, Gemini, Codex, OpenCode, Ollama, LM Studio, GitHub Models
+- 🔌 **Provider agnostic** — Claude, Gemini, Codex, OpenCode, Cursor Agent, Ollama, LM Studio, GitHub Models
 - 📦 **Zero dependencies** — Pure Bash, no Node/Python/Go required
 - 🪝 **Git native** — Standard pre-commit hook
 - ⚡ **Smart caching** — Skip unchanged files
@@ -122,6 +122,7 @@ gga install             # Install git hook
 | **Gemini** | `gemini` | [gemini-cli](https://github.com/google-gemini/gemini-cli) |
 | **Codex** | `codex` | `npm i -g @openai/codex` |
 | **OpenCode** | `opencode` | [opencode.ai](https://opencode.ai) |
+| **Cursor Agent** | `cursor[:model]` | [cursor.com](https://cursor.com) |
 | **Ollama** | `ollama:<model>` | [ollama.ai](https://ollama.ai) |
 | **LM Studio** | `lmstudio[:model]` | [lmstudio.ai](https://lmstudio.ai) |
 | **GitHub Models** | `github:<model>` | [marketplace/models](https://github.com/marketplace/models) |

--- a/bin/gga
+++ b/bin/gga
@@ -153,7 +153,7 @@ print_help() {
   echo ""
   echo -e "${BOLD}CONFIG OPTIONS:${NC}"
   echo "  PROVIDER           AI provider to use (required)"
-  echo "                     Values: claude, gemini, codex, opencode, ollama:<model>, lmstudio[:model], github:<model>"
+  echo "                     Values: claude, gemini, codex, opencode, cursor[:model], ollama:<model>, lmstudio[:model], github:<model>"
   echo "  FILE_PATTERNS      File patterns to review (default: *)"
   echo "                     Example: *.ts,*.tsx,*.js,*.jsx"
   echo "  EXCLUDE_PATTERNS   Patterns to exclude from review"
@@ -351,13 +351,15 @@ cmd_init() {
 # https://github.com/your-org/gga
 
 # AI Provider (required)
-# Options: claude, gemini, codex, opencode, ollama:<model>, lmstudio[:model], github:<model>
+# Options: claude, gemini, codex, opencode, cursor[:model], ollama:<model>, lmstudio[:model], github:<model>
 # Examples:
 #   PROVIDER="claude"
 #   PROVIDER="gemini"
 #   PROVIDER="codex"
 #   PROVIDER="opencode"
 #   PROVIDER="opencode:anthropic/claude-opus-4-5"
+#   PROVIDER="cursor"
+#   PROVIDER="cursor:composer-2"
 #   PROVIDER="ollama:llama3.2"
 #   PROVIDER="ollama:codellama"
 #   PROVIDER="lmstudio"

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -16,6 +16,7 @@ Use whichever AI CLI you have installed:
 | **Gemini**        | `gemini`           | `echo "prompt" \| gemini`         | [github.com/google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli) |
 | **Codex**         | `codex`            | `codex exec "prompt"`             | `npm i -g @openai/codex`                                                           |
 | **OpenCode**      | `opencode`         | `echo "prompt" \| opencode run`   | [opencode.ai](https://opencode.ai)                                                 |
+| **Cursor Agent**  | `cursor[:model]`   | `echo "prompt" \| cursor-agent -p --output-format text` | [cursor.com](https://cursor.com)                                      |
 | **Ollama**        | `ollama:<model>`   | `ollama run <model> "prompt"`     | [ollama.ai](https://ollama.ai)                                                     |
 | **LM Studio**     | `lmstudio[:model]` | HTTP API call to local server     | [lmstudio.ai](https://lmstudio.ai)                                                 |
 | **GitHub Models** | `github:<model>`   | HTTP API via `gh auth token`      | [github.com/marketplace/models](https://github.com/marketplace/models)              |
@@ -39,6 +40,12 @@ PROVIDER="opencode"
 
 # Use OpenCode with specific model
 PROVIDER="opencode:anthropic/claude-opus-4-5"
+
+# Use Cursor Agent with default model
+PROVIDER="cursor"
+
+# Use Cursor Agent with specific model
+PROVIDER="cursor:composer-2"
 
 # Use Ollama with Llama 3.2
 PROVIDER="ollama:llama3.2"
@@ -100,6 +107,20 @@ Google's Gemini CLI. Built into Antigravity IDE.
 # Test it works
 echo "Say hello" | gemini
 ```
+
+### Cursor Agent
+
+Uses Cursor Agent CLI in headless mode through your Cursor account.
+
+```bash
+# Install Cursor Agent CLI
+curl https://cursor.com/install -fsS | bash
+
+# Test it works
+printf 'Say hello' | cursor-agent -p --output-format text
+```
+
+GGA also accepts the legacy `agent` binary name when `cursor-agent` is not available.
 
 ### GitHub Models
 

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -8,6 +8,7 @@
 # - gemini: Google Gemini CLI
 # - codex: OpenAI Codex CLI
 # - opencode: OpenCode CLI (optional :model)
+# - cursor: Cursor Agent CLI (optional :model)
 # - ollama:<model>: Ollama with specified model
 # - lmstudio[:model]: LM Studio (optional model)
 # - github:<model>: GitHub Models (OpenAI-compatible API)
@@ -66,6 +67,16 @@ validate_provider() {
         echo ""
         echo "Install OpenCode CLI:"
         echo "  https://opencode.ai"
+        echo ""
+        return 1
+      fi
+      ;;
+    cursor)
+      if ! get_cursor_command >/dev/null; then
+        echo -e "${RED}❌ Cursor Agent CLI not found${NC}"
+        echo ""
+        echo "Install Cursor Agent CLI:"
+        echo "  curl https://cursor.com/install -fsS | bash"
         echo ""
         return 1
       fi
@@ -155,6 +166,7 @@ validate_provider() {
       echo "  - gemini"
       echo "  - codex"
       echo "  - opencode"
+      echo "  - cursor[:model]"
       echo "  - ollama:<model>"
       echo "  - lmstudio[:model]"
       echo "  - github:<model>"
@@ -191,6 +203,13 @@ execute_provider() {
         model=""
       fi
       execute_opencode "$model" "$prompt"
+      ;;
+    cursor)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" ]]; then
+        model=""
+      fi
+      execute_cursor "$model" "$prompt"
       ;;
     ollama)
       local model="${provider#*:}"
@@ -297,6 +316,38 @@ execute_opencode() {
     opencode run "${opencode_args[@]}" -- "$prompt" 2>&1
   fi
   return $?
+}
+
+get_cursor_command() {
+  if command -v cursor-agent >/dev/null 2>&1; then
+    echo "cursor-agent"
+    return 0
+  fi
+  if command -v agent >/dev/null 2>&1; then
+    echo "agent"
+    return 0
+  fi
+  return 1
+}
+
+execute_cursor() {
+  local model="$1"
+  local prompt="$2"
+  local cursor_cmd
+
+  if ! cursor_cmd=$(get_cursor_command); then
+    echo "Error: Cursor Agent CLI not found" >&2
+    return 1
+  fi
+
+  # Cursor Agent headless mode accepts the prompt through stdin when -p is set.
+  # The timeout path also uses stdin to avoid ARG_MAX for normal GGA runs.
+  if [[ -n "$model" ]]; then
+    printf '%s' "$prompt" | "$cursor_cmd" -p --model "$model" --output-format text 2>&1
+  else
+    printf '%s' "$prompt" | "$cursor_cmd" -p --output-format text 2>&1
+  fi
+  return "${PIPESTATUS[1]}"
 }
 
 execute_ollama() {
@@ -686,6 +737,14 @@ get_provider_info() {
         echo "OpenCode CLI (${details[*]})"
       fi
       ;;
+    cursor)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" || -z "$model" ]]; then
+        echo "Cursor Agent CLI"
+      else
+        echo "Cursor Agent CLI (model: $model)"
+      fi
+      ;;
     ollama)
       local model="${provider#*:}"
       echo "Ollama (model: $model)"
@@ -833,7 +892,7 @@ execute_with_timeout() {
 # Execute provider with timeout and progress feedback
 # Usage: execute_provider_with_timeout <provider> <prompt> <timeout>
 #
-# For CLI providers (claude, gemini, codex, opencode), the prompt is written to a
+# For CLI providers (claude, gemini, codex, opencode, cursor), the prompt is written to a
 # temp file and piped via stdin to avoid ARG_MAX limits on Windows (~8KB-32KB),
 # macOS (~256KB), and Linux (~128KB-2MB). Only the file path (short string) is
 # passed as an argument to execute_with_timeout, never the prompt content.
@@ -845,7 +904,7 @@ execute_provider_with_timeout() {
   local result=0
 
   case "$base_provider" in
-    claude|gemini|codex|opencode)
+    claude|gemini|codex|opencode|cursor)
       # Write prompt to temp file ONCE to avoid ARG_MAX limits.
       # This is critical for large PRs that generate prompts > 128KB-256KB.
       # Only CLI providers are handled here. API-based providers keep their
@@ -921,6 +980,31 @@ execute_provider_with_timeout() {
             # shellcheck disable=SC2016
             execute_with_timeout "$timeout" "OpenCode" \
               bash -c 'exec opencode run "${@:2}" < "$1"' _ "$prompt_file" "${opencode_args[@]}"
+          fi
+          result=$?
+          ;;
+        cursor)
+          local model="${provider#*:}"
+          local cursor_cmd
+          if [[ "$model" == "$provider" ]]; then
+            model=""
+          fi
+          if ! cursor_cmd=$(get_cursor_command); then
+            echo "Error: Cursor Agent CLI not found" >&2
+            rm -f "$prompt_file"
+            trap - RETURN
+            return 1
+          fi
+          if [[ -n "$model" ]]; then
+            # Keep prompt content out of argv while passing command/model as
+            # positional shell arguments.
+            # shellcheck disable=SC2016
+            execute_with_timeout "$timeout" "Cursor Agent" \
+              bash -c 'exec "$2" -p --model "$3" --output-format text < "$1"' _ "$prompt_file" "$cursor_cmd" "$model"
+          else
+            # shellcheck disable=SC2016
+            execute_with_timeout "$timeout" "Cursor Agent" \
+              bash -c 'exec "$2" -p --output-format text < "$1"' _ "$prompt_file" "$cursor_cmd"
           fi
           result=$?
           ;;

--- a/spec/unit/providers_argmax_behavior_spec.sh
+++ b/spec/unit/providers_argmax_behavior_spec.sh
@@ -71,7 +71,30 @@ done
 cat
 FAKE
 
-    chmod +x "$TEST_BIN_DIR/claude" "$TEST_BIN_DIR/gemini" "$TEST_BIN_DIR/codex" "$TEST_BIN_DIR/opencode"
+    cat > "$TEST_BIN_DIR/cursor-agent" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" != "-p" ]]; then
+  echo "unexpected cursor args: $*" >&2
+  exit 64
+fi
+shift
+if [[ "${1:-}" == "--model" ]]; then
+  echo "CURSOR_MODEL:$2"
+  shift 2
+fi
+if [[ "${1:-}" != "--output-format" || "${2:-}" != "text" ]]; then
+  echo "missing cursor output format: $*" >&2
+  exit 64
+fi
+shift 2
+if [[ $# -ne 0 ]]; then
+  echo "unexpected cursor positional prompt: $*" >&2
+  exit 64
+fi
+cat
+FAKE
+
+    chmod +x "$TEST_BIN_DIR/claude" "$TEST_BIN_DIR/gemini" "$TEST_BIN_DIR/codex" "$TEST_BIN_DIR/opencode" "$TEST_BIN_DIR/cursor-agent"
   }
   BeforeEach 'setup'
 
@@ -125,6 +148,23 @@ FAKE
     The output should include "line 1"
     The output should include "line 2"
     The stderr should include "Waiting for OpenCode"
+  End
+
+  It 'passes the full prompt to cursor via stdin without positional prompt args'
+    When call execute_provider_with_timeout "cursor" $'line 1\nline 2' 5
+    The status should be success
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for Cursor Agent"
+  End
+
+  It 'passes cursor model separately and prompt via stdin'
+    When call execute_provider_with_timeout "cursor:composer-2" $'line 1\nline 2' 5
+    The status should be success
+    The output should include "CURSOR_MODEL:composer-2"
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for Cursor Agent"
   End
 
   It 'passes opencode variant and agent flags while keeping prompt on stdin'

--- a/spec/unit/providers_cursor_spec.sh
+++ b/spec/unit/providers_cursor_spec.sh
@@ -1,0 +1,84 @@
+# shellcheck shell=bash
+
+Describe 'providers.sh cursor support'
+  Include "$LIB_DIR/providers.sh"
+
+  Describe 'get_provider_info()'
+    It 'returns info for cursor'
+      When call get_provider_info "cursor"
+      The output should include "Cursor Agent"
+    End
+
+    It 'returns info for cursor with model'
+      When call get_provider_info "cursor:composer-2"
+      The output should include "Cursor Agent"
+      The output should include "model: composer-2"
+    End
+  End
+
+  Describe 'execute_cursor()'
+    cursor-agent() {
+      if [[ "$1" != "-p" ]]; then
+        echo "unexpected cursor args: $*" >&2
+        return 64
+      fi
+      shift
+      if [[ "${1:-}" == "--model" ]]; then
+        echo "Model: $2"
+        shift 2
+      fi
+      if [[ "${1:-}" != "--output-format" || "${2:-}" != "text" ]]; then
+        echo "missing output format: $*" >&2
+        return 64
+      fi
+      cat
+    }
+
+    It 'executes cursor with default model'
+      When call execute_cursor "" "test prompt"
+      The status should be success
+      The output should include "test prompt"
+    End
+
+    It 'executes cursor with specific model'
+      When call execute_cursor "composer-2" "test prompt"
+      The status should be success
+      The output should include "Model: composer-2"
+      The output should include "test prompt"
+    End
+
+    It 'falls back to legacy agent binary when cursor-agent is unavailable'
+      local test_bin original_path
+      test_bin=$(mktemp -d)
+      original_path="$PATH"
+      cat > "$test_bin/agent" <<'FAKE'
+#!/bin/bash
+if [[ "$1" != "-p" ]]; then
+  echo "unexpected args: $*" >&2
+  exit 64
+fi
+/bin/cat
+FAKE
+      chmod +x "$test_bin/agent"
+      unset -f cursor-agent
+      PATH="$test_bin"
+
+      When call execute_cursor "" "test prompt"
+
+      The status should be success
+      The output should include "test prompt"
+      PATH="$original_path"
+      rm -rf "$test_bin"
+    End
+  End
+
+  Describe 'validate_provider() - cursor'
+    It 'succeeds when cursor-agent CLI is available'
+      cursor-agent() { return 0; }
+
+      When call validate_provider "cursor"
+      The status should be success
+    End
+
+  End
+End


### PR DESCRIPTION
## Summary
Add Cursor Agent CLI as a first-class GGA provider.

## Changes
- Add `cursor[:model]` provider validation, info, and execution.
- Use `cursor-agent` with fallback to legacy `agent` binary.
- Preserve ARG_MAX-safe timeout execution by feeding prompts through stdin.
- Document Cursor Agent in README and provider docs.
- Add unit coverage for validation, direct execution, model handling, legacy fallback, and timeout stdin handoff.

## Testing
- `shellspec spec/unit/providers_cursor_spec.sh spec/unit/providers_argmax_behavior_spec.sh spec/integration/commands_spec.sh`
- `make lint`

Closes #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cursor Agent as a provider throughout the app, including model-specific usage.
  * Expanded help, setup, and documentation with Cursor Agent examples and installation guidance.
  * Added support for a fallback binary name when the primary Cursor command isn’t available.

* **Tests**
  * Added coverage for Cursor Agent provider detection, execution, and prompt handling.
  * Added checks for model-specific behavior and stdin-based prompt delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->