### PR TITLE
fix(providers): send API payloads through stdin

### DIFF
--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -414,11 +414,12 @@ print(payload)
   # Remove trailing slash from host if present
   host="${host%/}"
   
-  # Call Ollama API
+  # Call Ollama API. Send the payload through stdin so large prompts do not
+  # travel through argv and hit ARG_MAX on Git Bash/MSYS or macOS.
   local api_response
-  api_response=$(curl -s --fail-with-body \
+  api_response=$(printf '%s' "$json_payload" | curl -s --fail-with-body \
     -H "Content-Type: application/json" \
-    -d "$json_payload" \
+    --data-binary @- \
     "${host}/api/generate" 2>&1)
   
   local curl_status=$?
@@ -526,11 +527,12 @@ print(payload)
 
   local endpoint="${host}/chat/completions"
 
-  # Call LM Studio API
+  # Call LM Studio API. Send the payload through stdin so large prompts do not
+  # travel through argv and hit ARG_MAX on Git Bash/MSYS or macOS.
   local api_response
-  api_response=$(curl -s --fail-with-body \
+  api_response=$(printf '%s' "$json_payload" | curl -s --fail-with-body \
     -H "Content-Type: application/json" \
-    -d "$json_payload" \
+    --data-binary @- \
     "$endpoint" 2>&1)
 
   local curl_status=$?
@@ -573,9 +575,24 @@ execute_lmstudio_api_fallback() {
   fi
 
   # Build JSON payload manually (less safe, but works without python3)
+  local escaped_prompt=""
+  local line
+  local first_line=true
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line//\\/\\\\}"
+    line="${line//\"/\\\"}"
+    line="${line//$'\t'/\\t}"
+    if [[ "$first_line" == true ]]; then
+      escaped_prompt="$line"
+      first_line=false
+    else
+      escaped_prompt+="\\n$line"
+    fi
+  done <<< "$prompt"
+
   local json_payload
   json_payload="{\"model\":\"$model\",\"messages\":[{\"role\":\"user\",\"content\":\""
-  json_payload+="$(printf '%s' "$prompt" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | sed ':a;N;$!ba;s/\n/\\n/g')"
+  json_payload+="$escaped_prompt"
   json_payload+="\"}],\"temperature\":0.7,\"stream\":false}"
 
   # Ensure host ends with /v1
@@ -585,11 +602,12 @@ execute_lmstudio_api_fallback() {
 
   local endpoint="${host}/chat/completions"
 
-  # Call LM Studio API
+  # Call LM Studio API. Send the payload through stdin so large prompts do not
+  # travel through argv and hit ARG_MAX on Git Bash/MSYS or macOS.
   local api_response
-  api_response=$(curl -s --fail-with-body \
+  api_response=$(printf '%s' "$json_payload" | curl -s --fail-with-body \
     -H "Content-Type: application/json" \
-    -d "$json_payload" \
+    --data-binary @- \
     "$endpoint" 2>&1)
 
   local curl_status=$?
@@ -645,13 +663,14 @@ print(payload)
   fi
 
   # Call GitHub Models API
-  # Use -s (silent) without --fail-with-body so we always get the response body
-  # The python3 parser handles error responses from the API
+  # Use -s (silent) without --fail-with-body so we always get the response body.
+  # The python3 parser handles error responses from the API. Send the payload
+  # through stdin so large prompts do not travel through argv.
   local api_response
-  api_response=$(curl -sS \
+  api_response=$(printf '%s' "$json_payload" | curl -sS \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $token" \
-    -d "$json_payload" \
+    --data-binary @- \
     "$GITHUB_MODELS_ENDPOINT" 2>&1)
 
   local curl_status=$?

--- a/spec/unit/github_models_spec.sh
+++ b/spec/unit/github_models_spec.sh
@@ -93,7 +93,7 @@ Describe 'providers.sh GitHub Models support'
       }
 
       # Mock curl to verify it receives the right arguments
-      # curl args: -sS -H "Content-Type: ..." -H "Authorization: Bearer ..." -d "..." URL
+      # curl args: -sS -H "Content-Type: ..." -H "Authorization: Bearer ..." --data-binary @- URL
       curl() {
         # Check all args as a single string for the key values
         local all_args="$*"
@@ -160,6 +160,25 @@ EOF
       The stderr should include "Invalid JSON"
     End
 
+    It 'sends JSON payload through stdin instead of argv'
+      gh() { echo "fake-token"; }
+      curl() {
+        local args="$*"
+        local payload
+        payload=$(cat)
+        [[ "$args" == *"--data-binary @-"* ]] || { echo "missing stdin payload flag" >&2; return 64; }
+        for arg in "$@"; do
+          [[ "$arg" != "-d" && "$arg" != "--data" && "$arg" != "--data-raw" ]] || { echo "payload passed through argv" >&2; return 64; }
+        done
+        [[ "$payload" == *"large review prompt"* ]] || { echo "missing prompt in stdin payload" >&2; return 64; }
+        echo '{"choices": [{"message": {"content": "STATUS: PASSED"}}]}'
+      }
+
+      When call execute_github_models "gpt-4o" "large review prompt"
+      The status should be success
+      The output should include "STATUS: PASSED"
+    End
+
     It 'handles response with error field'
       gh() { echo "fake-token"; }
       curl() {
@@ -197,7 +216,7 @@ EOF
       gh() { echo "fake-token"; }
       # We can verify indirectly by checking the response works
       curl() {
-        # The payload should contain the model name - curl receives it via -d
+        # The payload should contain the model name in stdin
         cat <<'EOF'
 {
   "choices": [

--- a/spec/unit/providers_spec.sh
+++ b/spec/unit/providers_spec.sh
@@ -286,6 +286,24 @@ All good!"
       The output should include "STATUS: PASSED"
     End
 
+    It 'sends JSON payload through stdin instead of argv'
+      curl() {
+        local args="$*"
+        local payload
+        payload=$(cat)
+        [[ "$args" == *"--data-binary @-"* ]] || { echo "missing stdin payload flag" >&2; return 64; }
+        for arg in "$@"; do
+          [[ "$arg" != "-d" && "$arg" != "--data" && "$arg" != "--data-raw" ]] || { echo "payload passed through argv" >&2; return 64; }
+        done
+        [[ "$payload" == *"large review prompt"* ]] || { echo "missing prompt in stdin payload" >&2; return 64; }
+        echo '{"response": "STATUS: PASSED"}'
+      }
+
+      When call execute_ollama_api "llama3" "large review prompt" "http://localhost:11434"
+      The status should be success
+      The output should include "STATUS: PASSED"
+    End
+
     It 'handles invalid JSON response'
       curl() {
         echo 'not valid json'
@@ -453,6 +471,24 @@ EOF
       The output should include "STATUS: PASSED"
     End
 
+    It 'sends JSON payload through stdin instead of argv'
+      curl() {
+        local args="$*"
+        local payload
+        payload=$(cat)
+        [[ "$args" == *"--data-binary @-"* ]] || { echo "missing stdin payload flag" >&2; return 64; }
+        for arg in "$@"; do
+          [[ "$arg" != "-d" && "$arg" != "--data" && "$arg" != "--data-raw" ]] || { echo "payload passed through argv" >&2; return 64; }
+        done
+        [[ "$payload" == *"large review prompt"* ]] || { echo "missing prompt in stdin payload" >&2; return 64; }
+        echo '{"choices":[{"message":{"content":"STATUS: PASSED"}}]}'
+      }
+
+      When call execute_lmstudio_api "llama-3" "large review prompt" "http://localhost:1234/v1"
+      The status should be success
+      The output should include "STATUS: PASSED"
+    End
+
     It 'handles invalid JSON response'
       curl() {
         echo 'not valid json'
@@ -501,6 +537,26 @@ EOF
       When call execute_lmstudio_api "" "test" "http://localhost:1234/v1"
       The status should be success
       The output should eq "LOCAL_MODEL_RESPONSE"
+    End
+  End
+
+  Describe 'execute_lmstudio_api_fallback()'
+    It 'sends JSON payload through stdin instead of argv'
+      curl() {
+        local args="$*"
+        local payload
+        payload=$(cat)
+        [[ "$args" == *"--data-binary @-"* ]] || { echo "missing stdin payload flag" >&2; return 64; }
+        for arg in "$@"; do
+          [[ "$arg" != "-d" && "$arg" != "--data" && "$arg" != "--data-raw" ]] || { echo "payload passed through argv" >&2; return 64; }
+        done
+        [[ "$payload" == *"large review prompt"* ]] || { echo "missing prompt in stdin payload" >&2; return 64; }
+        echo '{"choices":[{"message":{"content":"STATUS: PASSED"}}]}'
+      }
+
+      When call execute_lmstudio_api_fallback "llama-3" "large review prompt" "http://localhost:1234/v1"
+      The status should be success
+      The output should include "STATUS: PASSED"
     End
   End
 


### PR DESCRIPTION
## Summary
Fix API provider ARG_MAX failures by sending JSON request payloads to curl through stdin instead of argv.

## Changes
- Use `--data-binary @-` for Ollama API, LM Studio API, LM Studio fallback, and GitHub Models requests.
- Preserve existing API response parsing and curl error handling.
- Replace the LM Studio fallback multiline escaping pipeline with Bash string handling to keep it portable on macOS/BSD sed.
- Add regression tests proving JSON payloads are read from stdin and not passed via `-d` argv.

## Testing
- [x] `shellspec spec/unit/providers_spec.sh spec/unit/github_models_spec.sh`
- [x] `make lint`
- [ ] `make test` locally, blocked by existing environment-dependent OpenCode integration failure in `spec/integration/opencode_spec.sh` (`execute_opencode() works with specific model`).

Closes #92


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when sending large requests to AI providers by avoiding command-line size limits.
  * Updated request handling for Ollama, LM Studio, and GitHub Models to work more consistently across platforms.
  * Refined prompt formatting in one fallback path to preserve line breaks and special characters more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->