### PR TITLE
feat(providers): add Kilo and MiniMax providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 <p align="center">
   <strong>Provider-agnostic code review using AI</strong><br>
-  Use Claude, Gemini, Codex, OpenCode, Cursor Agent, Ollama, LM Studio, GitHub Models, or any AI to enforce your coding standards.<br>
-  Zero dependencies. Pure Bash. Works everywhere.
+  Use Claude, Gemini, Codex, OpenCode, Cursor Agent, Kilo, Ollama, LM Studio, GitHub Models, MiniMax, or any AI to enforce your coding standards.<br>
+  Pure Bash core. Works everywhere.
 </p>
 
 <p align="center">
@@ -45,8 +45,8 @@ You have coding standards. Your team ignores them. Code reviews catch issues too
 └─────────────────┘     └──────────────┘     └─────────────────┘
 ```
 
-- 🔌 **Provider agnostic** — Claude, Gemini, Codex, OpenCode, Cursor Agent, Ollama, LM Studio, GitHub Models
-- 📦 **Zero dependencies** — Pure Bash, no Node/Python/Go required
+- 🔌 **Provider agnostic** — Claude, Gemini, Codex, OpenCode, Cursor Agent, Kilo, Ollama, LM Studio, GitHub Models, MiniMax
+- 📦 **Pure Bash core** — no runtime framework; individual providers may require their own CLI or API tooling
 - 🪝 **Git native** — Standard pre-commit hook
 - ⚡ **Smart caching** — Skip unchanged files
 - 🔍 **PR review mode** — Review full PRs, not just last commit
@@ -123,9 +123,11 @@ gga install             # Install git hook
 | **Codex** | `codex` | `npm i -g @openai/codex` |
 | **OpenCode** | `opencode` | [opencode.ai](https://opencode.ai) |
 | **Cursor Agent** | `cursor[:model]` | [cursor.com](https://cursor.com) |
+| **Kilo** | `kilo[:model]` | `npm install -g @kilocode/cli` |
 | **Ollama** | `ollama:<model>` | [ollama.ai](https://ollama.ai) |
 | **LM Studio** | `lmstudio[:model]` | [lmstudio.ai](https://lmstudio.ai) |
 | **GitHub Models** | `github:<model>` | [marketplace/models](https://github.com/marketplace/models) |
+| **MiniMax** | `minimax[:model]` | [platform.minimax.io](https://platform.minimax.io) |
 
 > 📖 See [docs/providers.md](docs/providers.md) for detailed examples and setup.
 

--- a/bin/gga
+++ b/bin/gga
@@ -153,7 +153,7 @@ print_help() {
   echo ""
   echo -e "${BOLD}CONFIG OPTIONS:${NC}"
   echo "  PROVIDER           AI provider to use (required)"
-  echo "                     Values: claude, gemini, codex, opencode, cursor[:model], ollama:<model>, lmstudio[:model], github:<model>"
+  echo "                     Values: claude, gemini, codex, opencode, cursor[:model], kilo[:model], ollama:<model>, lmstudio[:model], github:<model>, minimax[:model]"
   echo "  FILE_PATTERNS      File patterns to review (default: *)"
   echo "                     Example: *.ts,*.tsx,*.js,*.jsx"
   echo "  EXCLUDE_PATTERNS   Patterns to exclude from review"
@@ -351,7 +351,7 @@ cmd_init() {
 # https://github.com/your-org/gga
 
 # AI Provider (required)
-# Options: claude, gemini, codex, opencode, cursor[:model], ollama:<model>, lmstudio[:model], github:<model>
+# Options: claude, gemini, codex, opencode, cursor[:model], kilo[:model], ollama:<model>, lmstudio[:model], github:<model>, minimax[:model]
 # Examples:
 #   PROVIDER="claude"
 #   PROVIDER="gemini"
@@ -360,12 +360,16 @@ cmd_init() {
 #   PROVIDER="opencode:anthropic/claude-opus-4-5"
 #   PROVIDER="cursor"
 #   PROVIDER="cursor:composer-2"
+#   PROVIDER="kilo"
+#   PROVIDER="kilo:anthropic/claude-sonnet-4-5"
 #   PROVIDER="ollama:llama3.2"
 #   PROVIDER="ollama:codellama"
 #   PROVIDER="lmstudio"
 #   PROVIDER="lmstudio:qwen2.5-coder-7b-instruct"
 #   PROVIDER="github:gpt-4o"
 #   PROVIDER="github:deepseek-r1"
+#   PROVIDER="minimax"
+#   PROVIDER="minimax:MiniMax-M3"
 PROVIDER="claude"
 
 # File patterns to include in review (comma-separated)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -4,6 +4,8 @@
 
 Detailed setup and configuration for all supported AI providers.
 
+GGA's core is Bash-only. Provider-specific tools still apply: CLI providers require their CLI, and API providers require `curl`; providers that parse JSON responses use `python3` when noted.
+
 ---
 
 ## Providers Table
@@ -17,9 +19,11 @@ Use whichever AI CLI you have installed:
 | **Codex**         | `codex`            | `codex exec "prompt"`             | `npm i -g @openai/codex`                                                           |
 | **OpenCode**      | `opencode`         | `echo "prompt" \| opencode run`   | [opencode.ai](https://opencode.ai)                                                 |
 | **Cursor Agent**  | `cursor[:model]`   | `echo "prompt" \| cursor-agent -p --output-format text` | [cursor.com](https://cursor.com)                                      |
+| **Kilo**          | `kilo[:model]`     | `echo "prompt" \| kilo run --auto` | `npm install -g @kilocode/cli`                                                     |
 | **Ollama**        | `ollama:<model>`   | `ollama run <model> "prompt"`     | [ollama.ai](https://ollama.ai)                                                     |
 | **LM Studio**     | `lmstudio[:model]` | HTTP API call to local server     | [lmstudio.ai](https://lmstudio.ai)                                                 |
 | **GitHub Models** | `github:<model>`   | HTTP API via `gh auth token`      | [github.com/marketplace/models](https://github.com/marketplace/models)              |
+| **MiniMax**       | `minimax[:model]`  | HTTP API via `MINIMAX_API_KEY`    | [platform.minimax.io](https://platform.minimax.io)                                  |
 
 ---
 
@@ -46,6 +50,12 @@ PROVIDER="cursor"
 
 # Use Cursor Agent with specific model
 PROVIDER="cursor:composer-2"
+
+# Use Kilo with default model
+PROVIDER="kilo"
+
+# Use Kilo with specific model
+PROVIDER="kilo:anthropic/claude-sonnet-4-5"
 
 # Use Ollama with Llama 3.2
 PROVIDER="ollama:llama3.2"
@@ -74,6 +84,13 @@ PROVIDER="github:gpt-4o"
 PROVIDER="github:gpt-4.1"
 PROVIDER="github:deepseek-r1"
 PROVIDER="github:grok-3"
+
+# Use MiniMax with default model (MiniMax-M3)
+MINIMAX_API_KEY="your-api-key"
+PROVIDER="minimax"
+
+# Use MiniMax with specific model
+PROVIDER="minimax:MiniMax-M3"
 
 # Antigravity / VS Code users: use any provider CLI from your integrated terminal
 # Antigravity comes with Gemini built-in — just set:
@@ -121,6 +138,31 @@ printf 'Say hello' | cursor-agent -p --output-format text
 ```
 
 GGA also accepts the legacy `agent` binary name when `cursor-agent` is not available.
+
+### Kilo
+
+Uses Kilo CLI in non-interactive mode. GGA sends the review prompt through stdin to avoid ARG_MAX failures on large reviews.
+
+```bash
+# Install Kilo CLI
+npm install -g @kilocode/cli
+
+# Test it works
+printf 'Say hello' | kilo run --auto
+```
+
+### MiniMax
+
+Uses MiniMax's OpenAI-compatible chat completions API. GGA sends JSON payloads through curl stdin to avoid ARG_MAX failures on large reviews. Requires `curl` and `python3` for JSON payload/response handling.
+
+```bash
+# Get an API key from platform.minimax.io
+export MINIMAX_API_KEY=your-api-key
+
+# Configure GGA
+PROVIDER="minimax"              # uses MiniMax-M3
+PROVIDER="minimax:MiniMax-M3"   # explicit model
+```
 
 ### GitHub Models
 

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -9,9 +9,11 @@
 # - codex: OpenAI Codex CLI
 # - opencode: OpenCode CLI (optional :model)
 # - cursor: Cursor Agent CLI (optional :model)
+# - kilo: Kilo CLI (optional :model)
 # - ollama:<model>: Ollama with specified model
 # - lmstudio[:model]: LM Studio (optional model)
 # - github:<model>: GitHub Models (OpenAI-compatible API)
+# - minimax[:model]: MiniMax OpenAI-compatible API
 # ============================================================================
 
 # Colors (in case sourced independently)
@@ -77,6 +79,16 @@ validate_provider() {
         echo ""
         echo "Install Cursor Agent CLI:"
         echo "  curl https://cursor.com/install -fsS | bash"
+        echo ""
+        return 1
+      fi
+      ;;
+    kilo)
+      if ! command -v kilo &> /dev/null; then
+        echo -e "${RED}❌ Kilo CLI not found${NC}"
+        echo ""
+        echo "Install Kilo CLI:"
+        echo "  npm install -g @kilocode/cli"
         echo ""
         return 1
       fi
@@ -158,6 +170,36 @@ validate_provider() {
         return 1
       fi
       ;;
+    minimax)
+      if [[ -z "${MINIMAX_API_KEY:-}" ]]; then
+        echo -e "${RED}❌ MINIMAX_API_KEY not set${NC}"
+        echo ""
+        echo "Get your API key from:"
+        echo "  https://platform.minimax.io/user-center/basic-information/interface-key"
+        echo ""
+        echo "Then export it:"
+        echo "  export MINIMAX_API_KEY=your-api-key"
+        echo ""
+        return 1
+      fi
+      if ! command -v curl &> /dev/null; then
+        echo -e "${RED}❌ curl not found${NC}"
+        echo ""
+        echo "Install curl:"
+        echo "  # Most systems have it pre-installed"
+        echo "  # Ubuntu/Debian: sudo apt-get install curl"
+        echo "  # macOS: brew install curl"
+        echo ""
+        return 1
+      fi
+      if ! command -v python3 &> /dev/null; then
+        echo -e "${RED}❌ python3 not found${NC}"
+        echo ""
+        echo "MiniMax response parsing requires python3."
+        echo ""
+        return 1
+      fi
+      ;;
     *)
       echo -e "${RED}❌ Unknown provider: $provider${NC}"
       echo ""
@@ -167,9 +209,11 @@ validate_provider() {
       echo "  - codex"
       echo "  - opencode"
       echo "  - cursor[:model]"
+      echo "  - kilo[:model]"
       echo "  - ollama:<model>"
       echo "  - lmstudio[:model]"
       echo "  - github:<model>"
+      echo "  - minimax[:model]"
       echo ""
       return 1
       ;;
@@ -211,6 +255,13 @@ execute_provider() {
       fi
       execute_cursor "$model" "$prompt"
       ;;
+    kilo)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" ]]; then
+        model=""
+      fi
+      execute_kilo "$model" "$prompt"
+      ;;
     ollama)
       local model="${provider#*:}"
       execute_ollama "$model" "$prompt"
@@ -225,6 +276,13 @@ execute_provider() {
     github)
       local model="${provider#*:}"
       execute_github_models "$model" "$prompt"
+      ;;
+    minimax)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" || -z "$model" ]]; then
+        model="$MINIMAX_DEFAULT_MODEL"
+      fi
+      execute_minimax "$model" "$prompt"
       ;;
   esac
 }
@@ -346,6 +404,20 @@ execute_cursor() {
     printf '%s' "$prompt" | "$cursor_cmd" -p --model "$model" --output-format text 2>&1
   else
     printf '%s' "$prompt" | "$cursor_cmd" -p --output-format text 2>&1
+  fi
+  return "${PIPESTATUS[1]}"
+}
+
+execute_kilo() {
+  local model="$1"
+  local prompt="$2"
+
+  # Kilo CLI reads stdin when no positional message is passed.
+  # The timeout path also uses stdin to avoid ARG_MAX for normal GGA runs.
+  if [[ -n "$model" ]]; then
+    printf '%s' "$prompt" | kilo run --auto --model "$model" 2>&1
+  else
+    printf '%s' "$prompt" | kilo run --auto 2>&1
   fi
   return "${PIPESTATUS[1]}"
 }
@@ -716,6 +788,116 @@ except (KeyError, IndexError, TypeError) as e:
 }
 
 # ============================================================================
+# MiniMax Implementation
+# ============================================================================
+
+MINIMAX_ENDPOINT="https://api.minimax.io/v1/chat/completions"
+MINIMAX_DEFAULT_MODEL="MiniMax-M3"
+
+execute_minimax() {
+  local model="$1"
+  local prompt="$2"
+
+  if [[ -z "$model" ]]; then
+    model="$MINIMAX_DEFAULT_MODEL"
+  fi
+
+  local api_key="${MINIMAX_API_KEY:-}"
+  if [[ -z "$api_key" ]]; then
+    echo "Error: MINIMAX_API_KEY not set" >&2
+    return 1
+  fi
+
+  local json_payload
+  if ! json_payload=$(printf '%s' "$prompt" | python3 -c "
+import sys, json
+prompt = sys.stdin.read()
+model = sys.argv[1]
+payload = json.dumps({
+    'model': model,
+    'messages': [
+        {'role': 'system', 'content': 'You are a helpful code review assistant.'},
+        {'role': 'user', 'content': prompt}
+    ],
+    'temperature': 0.2,
+    'stream': False
+})
+print(payload)
+" "$model" 2>&1); then
+    echo "Error: Failed to build JSON payload" >&2
+    echo "$json_payload" >&2
+    return 1
+  fi
+
+  local curl_config_file
+  if ! curl_config_file=$(mktemp "${TEMP:-${TMPDIR:-/tmp}}/gga_minimax_curl.XXXXXX"); then
+    echo "Error: Failed to create temporary MiniMax curl config" >&2
+    return 1
+  fi
+  chmod 600 "$curl_config_file" 2>/dev/null || true
+  if ! {
+    printf '%s\n' 'header = "Content-Type: application/json"'
+    printf 'header = "Authorization: Bearer %s"\n' "$api_key"
+  } > "$curl_config_file"; then
+    echo "Error: Failed to write temporary MiniMax curl config" >&2
+    rm -f "$curl_config_file"
+    return 1
+  fi
+
+  local api_response
+  api_response=$(printf '%s' "$json_payload" | curl -sS \
+    --config "$curl_config_file" \
+    --data-binary @- \
+    "$MINIMAX_ENDPOINT" 2>&1)
+
+  local curl_status=$?
+  rm -f "$curl_config_file"
+  if [[ $curl_status -ne 0 ]]; then
+    echo "Error: Failed to connect to MiniMax API" >&2
+    echo "$api_response" >&2
+    return 1
+  fi
+
+  printf '%s' "$api_response" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    if 'error' in data:
+        error = data['error']
+        if isinstance(error, dict):
+            msg = error.get('message') or error.get('status_msg') or str(error)
+        else:
+            msg = str(error)
+        print(f'Error: {msg}', file=sys.stderr)
+        sys.exit(1)
+    if 'base_resp' in data and isinstance(data['base_resp'], dict):
+        base_resp = data['base_resp']
+        status_code = base_resp.get('status_code')
+        if status_code not in (None, 0):
+            msg = base_resp.get('status_msg', 'Unknown error from MiniMax')
+            print(f'Error: {msg}', file=sys.stderr)
+            sys.exit(1)
+    choices = data.get('choices', [])
+    if not choices:
+        print('Error: Unexpected response format from MiniMax', file=sys.stderr)
+        sys.exit(1)
+    content = choices[0].get('message', {}).get('content', '')
+    if content:
+        print(content)
+    else:
+        print('Error: Empty response from MiniMax', file=sys.stderr)
+        sys.exit(1)
+except json.JSONDecodeError as e:
+    print(f'Error: Invalid JSON response from MiniMax: {e}', file=sys.stderr)
+    sys.exit(1)
+except (KeyError, IndexError, TypeError) as e:
+    print('Error: Unexpected response format from MiniMax', file=sys.stderr)
+    sys.exit(1)
+"
+  return $?
+}
+
+# ============================================================================
 # Provider Info
 # ============================================================================
 
@@ -764,6 +946,14 @@ get_provider_info() {
         echo "Cursor Agent CLI (model: $model)"
       fi
       ;;
+    kilo)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" || -z "$model" ]]; then
+        echo "Kilo CLI"
+      else
+        echo "Kilo CLI (model: $model)"
+      fi
+      ;;
     ollama)
       local model="${provider#*:}"
       echo "Ollama (model: $model)"
@@ -780,6 +970,13 @@ get_provider_info() {
       local model="${provider#*:}"
       echo "GitHub Models (model: $model)"
       ;;
+    minimax)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" || -z "$model" ]]; then
+        model="$MINIMAX_DEFAULT_MODEL"
+      fi
+      echo "MiniMax (model: $model)"
+      ;;
     *)
       echo "Unknown provider"
       ;;
@@ -789,6 +986,29 @@ get_provider_info() {
 # ============================================================================
 # Timeout Wrapper with Progress Feedback
 # ============================================================================
+
+collect_process_tree() {
+  local root_pid="$1"
+  local child
+
+  echo "$root_pid"
+  if command -v pgrep >/dev/null 2>&1; then
+    while IFS= read -r child; do
+      [[ -n "$child" ]] || continue
+      collect_process_tree "$child"
+    done < <(pgrep -P "$root_pid" 2>/dev/null || true)
+  fi
+}
+
+kill_process_list() {
+  local signal="$1"
+  shift
+  local pid
+
+  for pid in "$@"; do
+    kill "-$signal" "$pid" 2>/dev/null || true
+  done
+}
 
 # Execute a command with timeout and progress feedback
 # Usage: execute_with_timeout <timeout_seconds> <provider_name> <command...>
@@ -834,10 +1054,16 @@ execute_with_timeout() {
     local elapsed=$((SECONDS - start_time))
 
     if [[ $elapsed -ge $timeout_seconds ]]; then
-      # Timeout reached - kill the process tree
-      kill -TERM "$cmd_pid" 2>/dev/null || true
+      # Timeout reached - kill the process tree. Snapshot descendants before
+      # TERM so ignored signals or a fast-exiting wrapper cannot reparent child
+      # CLIs before the KILL pass.
+      local -a process_tree=()
+      while IFS= read -r tree_pid; do
+        [[ -n "$tree_pid" ]] && process_tree+=("$tree_pid")
+      done < <(collect_process_tree "$cmd_pid")
+      kill_process_list TERM "${process_tree[@]}"
       sleep 0.5
-      kill -KILL "$cmd_pid" 2>/dev/null || true
+      kill_process_list KILL "${process_tree[@]}"
       wait "$cmd_pid" 2>/dev/null || true
 
       # Clear spinner line if in TTY mode
@@ -911,7 +1137,7 @@ execute_with_timeout() {
 # Execute provider with timeout and progress feedback
 # Usage: execute_provider_with_timeout <provider> <prompt> <timeout>
 #
-# For CLI providers (claude, gemini, codex, opencode, cursor), the prompt is written to a
+# For CLI providers (claude, gemini, codex, opencode, cursor, kilo), the prompt is written to a
 # temp file and piped via stdin to avoid ARG_MAX limits on Windows (~8KB-32KB),
 # macOS (~256KB), and Linux (~128KB-2MB). Only the file path (short string) is
 # passed as an argument to execute_with_timeout, never the prompt content.
@@ -923,7 +1149,7 @@ execute_provider_with_timeout() {
   local result=0
 
   case "$base_provider" in
-    claude|gemini|codex|opencode|cursor)
+    claude|gemini|codex|opencode|cursor|kilo)
       # Write prompt to temp file ONCE to avoid ARG_MAX limits.
       # This is critical for large PRs that generate prompts > 128KB-256KB.
       # Only CLI providers are handled here. API-based providers keep their
@@ -1027,6 +1253,23 @@ execute_provider_with_timeout() {
           fi
           result=$?
           ;;
+        kilo)
+          local model="${provider#*:}"
+          if [[ "$model" == "$provider" ]]; then
+            model=""
+          fi
+          if [[ -n "$model" ]]; then
+            # Kilo run reads stdin when no positional message args are passed.
+            # shellcheck disable=SC2016
+            execute_with_timeout "$timeout" "Kilo" \
+              bash -c 'exec kilo run --auto --model "$2" < "$1"' _ "$prompt_file" "$model"
+          else
+            # shellcheck disable=SC2016
+            execute_with_timeout "$timeout" "Kilo" \
+              bash -c 'exec kilo run --auto < "$1"' _ "$prompt_file"
+          fi
+          result=$?
+          ;;
       esac
 
       # Cleanup temp file (also handled by trap, but explicit is clearer)
@@ -1058,6 +1301,15 @@ execute_provider_with_timeout() {
       fi
 
       execute_with_timeout "$timeout" "LM Studio" execute_lmstudio "$model" "$prompt"
+      result=$?
+      ;;
+    minimax)
+      local model="${provider#*:}"
+      if [[ "$model" == "$provider" || -z "$model" ]]; then
+        model="$MINIMAX_DEFAULT_MODEL"
+      fi
+
+      execute_with_timeout "$timeout" "MiniMax ($model)" execute_minimax "$model" "$prompt"
       result=$?
       ;;
     *)

--- a/spec/unit/providers_argmax_behavior_spec.sh
+++ b/spec/unit/providers_argmax_behavior_spec.sh
@@ -94,7 +94,25 @@ fi
 cat
 FAKE
 
-    chmod +x "$TEST_BIN_DIR/claude" "$TEST_BIN_DIR/gemini" "$TEST_BIN_DIR/codex" "$TEST_BIN_DIR/opencode" "$TEST_BIN_DIR/cursor-agent"
+    cat > "$TEST_BIN_DIR/kilo" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" != "run" || "$2" != "--auto" ]]; then
+  echo "unexpected kilo args: $*" >&2
+  exit 64
+fi
+shift 2
+if [[ "${1:-}" == "--model" ]]; then
+  echo "KILO_MODEL:$2"
+  shift 2
+fi
+if [[ $# -ne 0 ]]; then
+  echo "unexpected kilo positional prompt: $*" >&2
+  exit 64
+fi
+cat
+FAKE
+
+    chmod +x "$TEST_BIN_DIR/claude" "$TEST_BIN_DIR/gemini" "$TEST_BIN_DIR/codex" "$TEST_BIN_DIR/opencode" "$TEST_BIN_DIR/cursor-agent" "$TEST_BIN_DIR/kilo"
   }
   BeforeEach 'setup'
 
@@ -165,6 +183,23 @@ FAKE
     The output should include "line 1"
     The output should include "line 2"
     The stderr should include "Waiting for Cursor Agent"
+  End
+
+  It 'passes the full prompt to kilo via stdin without positional prompt args'
+    When call execute_provider_with_timeout "kilo" $'line 1\nline 2' 5
+    The status should be success
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for Kilo"
+  End
+
+  It 'passes kilo model separately and prompt via stdin'
+    When call execute_provider_with_timeout "kilo:anthropic/claude-sonnet-4-5" $'line 1\nline 2' 5
+    The status should be success
+    The output should include "KILO_MODEL:anthropic/claude-sonnet-4-5"
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for Kilo"
   End
 
   It 'passes opencode variant and agent flags while keeping prompt on stdin'

--- a/spec/unit/providers_argmax_spec.sh
+++ b/spec/unit/providers_argmax_spec.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 
 # Tests for ARG_MAX fix - execute_provider_with_timeout should handle large prompts
-# via temp files for CLI providers (claude, gemini, codex, opencode).
+# via temp files for CLI providers (claude, gemini, codex, opencode, cursor, kilo).
 # Related issues: #77 (macOS), #87 (Windows), #58, #85
 
 Describe 'providers.sh ARG_MAX handling'
@@ -25,6 +25,7 @@ Describe 'providers.sh ARG_MAX handling'
     codex() { cat; }
     opencode() { cat; }
     gemini() { cat; }
+    kilo() { cat; }
 
     It 'writes prompt to temp file for claude'
       When call execute_provider_with_timeout "claude" "test prompt" 300
@@ -61,6 +62,13 @@ Describe 'providers.sh ARG_MAX handling'
       The output should include "TIMEOUT:300:Gemini"
       The output should include "bash -c"
       The output should include "exec gemini -p"
+    End
+
+    It 'writes prompt to temp file for kilo'
+      When call execute_provider_with_timeout "kilo" "test prompt" 300
+      The output should include "TIMEOUT:300:Kilo"
+      The output should include "bash -c"
+      The output should include "kilo run --auto"
     End
 
     It 'handles large prompts without ARG_MAX errors'
@@ -141,9 +149,8 @@ Describe 'providers.sh ARG_MAX handling'
   End
 
   Describe 'execute_provider_with_timeout() - API providers unchanged'
-    # API-based providers (ollama, lmstudio) are intentionally left on their
-    # existing execution path in this PR. Their prompt transport is covered by
-    # separate API-provider tests/issues.
+    # API-based providers (ollama, lmstudio, minimax) keep their API execution path.
+    # Their curl payload transport is covered by separate API-provider tests.
 
     It 'does not use temp file for ollama'
       # Mock execute_with_timeout to avoid progress output warnings and execute
@@ -201,6 +208,19 @@ Describe 'providers.sh ARG_MAX handling'
 
       When call execute_provider_with_timeout "lmstudio:llama-3" "test prompt" 300
       The status should eq 42
+    End
+
+    It 'does not use temp file for minimax'
+      execute_with_timeout() {
+        shift 2
+        "$@"
+      }
+      execute_minimax() {
+        echo "MINIMAX_CALLED:$1:$2"
+      }
+
+      When call execute_provider_with_timeout "minimax:MiniMax-M3" "test prompt" 300
+      The output should include "MINIMAX_CALLED:MiniMax-M3:test prompt"
     End
 
     It 'propagates exit code for generic fallback'

--- a/spec/unit/providers_kilo_spec.sh
+++ b/spec/unit/providers_kilo_spec.sh
@@ -1,0 +1,72 @@
+# shellcheck shell=bash
+
+Describe 'providers.sh kilo support'
+  Include "$LIB_DIR/providers.sh"
+
+  Describe 'get_provider_info()'
+    It 'returns info for kilo'
+      When call get_provider_info "kilo"
+      The output should include "Kilo CLI"
+    End
+
+    It 'returns info for kilo with model'
+      When call get_provider_info "kilo:anthropic/claude-sonnet-4-5"
+      The output should include "Kilo CLI"
+      The output should include "model: anthropic/claude-sonnet-4-5"
+    End
+  End
+
+  Describe 'execute_kilo()'
+    kilo() {
+      if [[ "$1" != "run" || "$2" != "--auto" ]]; then
+        echo "unexpected kilo args: $*" >&2
+        return 64
+      fi
+      shift 2
+      if [[ "${1:-}" == "--model" ]]; then
+        echo "MODEL:$2"
+        shift 2
+      fi
+      if [[ $# -ne 0 ]]; then
+        echo "unexpected kilo positional prompt: $*" >&2
+        return 64
+      fi
+      cat
+    }
+
+    It 'executes kilo with default model'
+      When call execute_kilo "" "test prompt"
+      The status should be success
+      The output should include "test prompt"
+    End
+
+    It 'executes kilo with specific model'
+      When call execute_kilo "anthropic/claude-sonnet-4-5" "test prompt"
+      The status should be success
+      The output should include "MODEL:anthropic/claude-sonnet-4-5"
+      The output should include "test prompt"
+    End
+  End
+
+  Describe 'validate_provider() - kilo'
+    It 'succeeds when kilo CLI is available'
+      kilo() { return 0; }
+
+      When call validate_provider "kilo"
+      The status should be success
+    End
+
+    It 'fails when kilo CLI is unavailable'
+      command() {
+        case "$2" in
+          kilo) return 1 ;;
+          *) builtin command "$@" ;;
+        esac
+      }
+
+      When call validate_provider "kilo"
+      The status should be failure
+      The output should include "Kilo CLI not found"
+    End
+  End
+End

--- a/spec/unit/providers_minimax_spec.sh
+++ b/spec/unit/providers_minimax_spec.sh
@@ -1,0 +1,148 @@
+# shellcheck shell=bash
+
+Describe 'providers.sh MiniMax support'
+  Include "$LIB_DIR/providers.sh"
+
+  Describe 'validate_provider() - minimax'
+    It 'fails when MINIMAX_API_KEY is not set'
+      unset MINIMAX_API_KEY
+
+      When call validate_provider "minimax"
+      The status should be failure
+      The output should include "MINIMAX_API_KEY not set"
+    End
+
+    It 'succeeds when MINIMAX_API_KEY, curl, and python3 are available'
+      MINIMAX_API_KEY="fake-key"
+      command() {
+        case "$2" in
+          curl|python3) return 0 ;;
+          *) return 1 ;;
+        esac
+      }
+
+      When call validate_provider "minimax:MiniMax-M3"
+      The status should be success
+    End
+  End
+
+  Describe 'get_provider_info() - minimax'
+    It 'uses default model when none is specified'
+      When call get_provider_info "minimax"
+      The output should include "MiniMax"
+      The output should include "MiniMax-M3"
+    End
+
+    It 'returns info for explicit model'
+      When call get_provider_info "minimax:MiniMax-M2.7"
+      The output should include "MiniMax"
+      The output should include "MiniMax-M2.7"
+    End
+  End
+
+  Describe 'execute_minimax()'
+    skip_if_no_python3() {
+      ! command -v python3 &> /dev/null
+    }
+
+    Skip if "python3 not available" skip_if_no_python3
+
+    It 'sends JSON payload through stdin instead of argv'
+      MINIMAX_API_KEY="fake-key"
+      curl() {
+        local args="$*"
+        local payload config_file=""
+        payload=$(cat)
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --config)
+              config_file="$2"
+              shift 2
+              ;;
+            *) shift ;;
+          esac
+        done
+        [[ -n "$config_file" && -f "$config_file" ]] || { echo "missing curl config" >&2; return 64; }
+        grep -q 'Authorization: Bearer fake-key' "$config_file" || { echo "missing auth in config" >&2; return 64; }
+        [[ "$args" != *"Authorization: Bearer fake-key"* ]] || { echo "auth leaked through argv" >&2; return 64; }
+        [[ "$args" == *"--data-binary @-"* ]] || { echo "missing stdin payload flag" >&2; return 64; }
+        for arg in "$@"; do
+          [[ "$arg" != "-d" && "$arg" != "--data" && "$arg" != "--data-raw" ]] || { echo "payload passed through argv" >&2; return 64; }
+        done
+        [[ "$payload" == *"large review prompt"* ]] || { echo "missing prompt in stdin payload" >&2; return 64; }
+        echo '{"choices":[{"message":{"content":"STATUS: PASSED"}}]}'
+      }
+
+      When call execute_minimax "MiniMax-M3" "large review prompt"
+      The status should be success
+      The output should include "STATUS: PASSED"
+    End
+
+    It 'handles API error responses'
+      MINIMAX_API_KEY="fake-key"
+      curl() {
+        echo '{"error":{"message":"invalid api key"}}'
+      }
+
+      When call execute_minimax "MiniMax-M3" "test prompt"
+      The status should be failure
+      The stderr should include "invalid api key"
+    End
+
+    It 'handles curl failures'
+      MINIMAX_API_KEY="fake-key"
+      curl() {
+        echo "Connection refused"
+        return 7
+      }
+
+      When call execute_minimax "MiniMax-M3" "test prompt"
+      The status should be failure
+      The stderr should include "Failed to connect to MiniMax API"
+    End
+
+    It 'handles invalid JSON responses'
+      MINIMAX_API_KEY="fake-key"
+      curl() {
+        echo 'not valid json'
+      }
+
+      When call execute_minimax "MiniMax-M3" "test prompt"
+      The status should be failure
+      The stderr should include "Invalid JSON response from MiniMax"
+    End
+
+    It 'handles MiniMax base_resp errors'
+      MINIMAX_API_KEY="fake-key"
+      curl() {
+        echo '{"base_resp":{"status_code":1001,"status_msg":"quota exceeded"}}'
+      }
+
+      When call execute_minimax "MiniMax-M3" "test prompt"
+      The status should be failure
+      The stderr should include "quota exceeded"
+    End
+
+    It 'handles empty choices'
+      MINIMAX_API_KEY="fake-key"
+      curl() {
+        echo '{"choices":[]}'
+      }
+
+      When call execute_minimax "MiniMax-M3" "test prompt"
+      The status should be failure
+      The stderr should include "Unexpected response format from MiniMax"
+    End
+
+    It 'handles empty content'
+      MINIMAX_API_KEY="fake-key"
+      curl() {
+        echo '{"choices":[{"message":{"content":""}}]}'
+      }
+
+      When call execute_minimax "MiniMax-M3" "test prompt"
+      The status should be failure
+      The stderr should include "Empty response from MiniMax"
+    End
+  End
+End

--- a/spec/unit/timeout_spec.sh
+++ b/spec/unit/timeout_spec.sh
@@ -84,6 +84,30 @@ Describe 'execute_with_timeout()'
       The status should eq 124
       The stderr should include "Increase TIMEOUT"
     End
+
+    It 'terminates child processes after timeout'
+      local marker
+      marker=$(mktemp "${TEMP:-${TMPDIR:-/tmp}}/gga_timeout_marker.XXXXXX")
+      rm -f "$marker"
+
+      When call execute_with_timeout 1 "TestProvider" bash -c 'sleep 3; echo done > "$1"' _ "$marker"
+      The status should eq 124
+      The stderr should include "TIMEOUT"
+      sleep 3
+      Assert [ ! -e "$marker" ]
+    End
+
+    It 'kills child processes that ignore TERM'
+      local marker
+      marker=$(mktemp "${TEMP:-${TMPDIR:-/tmp}}/gga_timeout_marker.XXXXXX")
+      rm -f "$marker"
+
+      When call execute_with_timeout 1 "TestProvider" bash -c 'trap "" TERM; (trap "" TERM; sleep 3; echo done > "$1") & wait' _ "$marker"
+      The status should eq 124
+      The stderr should include "TIMEOUT"
+      sleep 3
+      Assert [ ! -e "$marker" ]
+    End
   End
 
   Describe 'progress feedback in non-TTY mode'


### PR DESCRIPTION
## Summary
Add Kilo CLI and MiniMax API as supported GGA providers.

## Changes
- Add `kilo[:model]` provider validation, execution, provider info, docs, and regression tests.
- Feed Kilo prompts through stdin in both direct and timeout paths to avoid ARG_MAX regressions.
- Add `minimax[:model]` provider using MiniMax's OpenAI-compatible chat completions API, defaulting to `MiniMax-M3`.
- Send MiniMax JSON payloads through curl stdin and keep the API key out of curl argv via a temporary curl config file.
- Harden timeout cleanup so child processes are terminated when a provider times out, including children that ignore `TERM`.
- Clarify docs that the GGA core is Bash-only while individual providers may require their own CLI/API tooling.

## Testing
- `shellspec spec/unit/timeout_spec.sh spec/unit/providers_kilo_spec.sh spec/unit/providers_minimax_spec.sh spec/unit/providers_argmax_behavior_spec.sh spec/unit/providers_argmax_spec.sh spec/integration/commands_spec.sh`
- `make lint`
- Fresh 4R review after >400-line diff:
  - `review-risk`: No findings
  - `review-resilience`: No findings
  - `review-reliability`: No findings
  - `review-readability`: warnings only, no blockers

Closes #68
Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new AI providers, including Kilo and MiniMax.
  * Expanded provider examples and configuration templates with more supported model formats.

* **Bug Fixes**
  * Improved timeout handling so timed-out commands clean up child processes more reliably.
  * Tightened provider execution so prompts and model selections are handled more consistently.

* **Documentation**
  * Updated the README and provider docs to reflect the latest supported providers and usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->