### PR TITLE
fix(windows): normalize config and cache paths

### DIFF
--- a/bin/gga
+++ b/bin/gga
@@ -13,6 +13,38 @@ VERSION="${GGA_VERSION:-dev}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$(dirname "$SCRIPT_DIR")/lib"
 
+resolve_lib_dir() {
+  local configured_lib_dir="$1"
+  local candidate
+  local -a candidates=(
+    "$configured_lib_dir"
+    "$SCRIPT_DIR/lib/gga"
+    "$(dirname "$SCRIPT_DIR")/lib/gga"
+    "$(dirname "$SCRIPT_DIR")/lib"
+  )
+
+  if command -v cygpath >/dev/null 2>&1; then
+    candidates+=("$(cygpath -u "$configured_lib_dir" 2>/dev/null || true)")
+  fi
+
+  for candidate in "${candidates[@]}"; do
+    [[ -n "$candidate" ]] || continue
+    if [[ -f "$candidate/providers.sh" && -f "$candidate/cache.sh" && -f "$candidate/pr_mode.sh" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  echo "$configured_lib_dir"
+  return 1
+}
+
+if ! LIB_DIR=$(resolve_lib_dir "$LIB_DIR"); then
+  echo "Error: GGA library files not found" >&2
+  echo "Expected providers.sh, cache.sh, and pr_mode.sh near: $LIB_DIR" >&2
+  exit 1
+fi
+
 # Source library functions
 # shellcheck source=lib/providers.sh
 source "$LIB_DIR/providers.sh"
@@ -68,6 +100,30 @@ UPDATE_CHECK_REPO="Gentleman-Programming/gentleman-guardian-angel"
 # ============================================================================
 # Helper Functions
 # ============================================================================
+
+normalize_bash_path() {
+  local path="$1"
+  local converted
+
+  if [[ -n "$path" && "$path" =~ ^[A-Za-z]:\\ ]] && command -v cygpath >/dev/null 2>&1; then
+    if converted=$(cygpath -u "$path" 2>/dev/null); then
+      printf '%s\n' "$converted"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "$path"
+}
+
+get_global_config_path() {
+  if [[ -n "${APPDATA:-}" ]]; then
+    printf '%s\n' "$(normalize_bash_path "$APPDATA")/gga/config"
+  elif [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+    printf '%s\n' "$(normalize_bash_path "$XDG_CONFIG_HOME")/gga/config"
+  else
+    printf '%s\n' "$HOME/.config/gga/config"
+  fi
+}
 
 # Check for newer version on GitHub (2s timeout, silent on failure)
 check_update() {
@@ -148,8 +204,8 @@ print_help() {
   echo "  --diff-only       With --pr-mode: send only diffs (faster, cheaper)"
   echo ""
   echo -e "${BOLD}CONFIGURATION:${NC}"
-  echo "  Create a ${CYAN}.gga${NC} file in your project root or"
-  echo "  ${CYAN}~/.config/gga/config${NC} for global settings."
+  echo -e "  Create a ${CYAN}.gga${NC} file in your project root or"
+  echo -e "  ${CYAN}~/.config/gga/config${NC} for global settings."
   echo ""
   echo -e "${BOLD}CONFIG OPTIONS:${NC}"
   echo "  PROVIDER           AI provider to use (required)"
@@ -209,6 +265,14 @@ log_error() {
 # Configuration Loading
 # ============================================================================
 
+sanitize_config_file() {
+  local config_file="$1"
+
+  # Strip UTF-8 BOM from the first line and CR from CRLF files before sourcing.
+  # This keeps Windows-edited .gga files readable without modifying user files.
+  sed $'1s/^\xef\xbb\xbf//' "$config_file" | tr -d '\r'
+}
+
 load_config() {
   # Reset to defaults
   PROVIDER=""
@@ -222,23 +286,17 @@ load_config() {
   OPENCODE_AGENT=""
 
   # Load global config first (platform-aware path)
-  if [[ -n "${APPDATA:-}" ]]; then
-    GLOBAL_CONFIG="${APPDATA}/gga/config"
-  elif [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
-    GLOBAL_CONFIG="${XDG_CONFIG_HOME}/gga/config"
-  else
-    GLOBAL_CONFIG="$HOME/.config/gga/config"
-  fi
+  GLOBAL_CONFIG=$(get_global_config_path)
   if [[ -f "$GLOBAL_CONFIG" ]]; then
     # shellcheck source=/dev/null
-    source "$GLOBAL_CONFIG"
+    source <(sanitize_config_file "$GLOBAL_CONFIG")
   fi
 
   # Load project config (overrides global)
   PROJECT_CONFIG=".gga"
   if [[ -f "$PROJECT_CONFIG" ]]; then
     # shellcheck source=/dev/null
-    source "$PROJECT_CONFIG"
+    source <(sanitize_config_file "$PROJECT_CONFIG")
   fi
 
   # Environment variable overrides everything
@@ -268,13 +326,7 @@ cmd_config() {
   echo ""
   
   # Check config sources (platform-aware path)
-  if [[ -n "${APPDATA:-}" ]]; then
-    GLOBAL_CONFIG="${APPDATA}/gga/config"
-  elif [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
-    GLOBAL_CONFIG="${XDG_CONFIG_HOME}/gga/config"
-  else
-    GLOBAL_CONFIG="$HOME/.config/gga/config"
-  fi
+  GLOBAL_CONFIG=$(get_global_config_path)
   PROJECT_CONFIG=".gga"
   
   echo -e "${BOLD}Config Files:${NC}"

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -10,10 +10,24 @@
 #   - Config file (.gga) changes
 # ============================================================================
 
+normalize_bash_path() {
+  local path="$1"
+  local converted
+
+  if [[ -n "$path" && "$path" =~ ^[A-Za-z]:\\ ]] && command -v cygpath >/dev/null 2>&1; then
+    if converted=$(cygpath -u "$path" 2>/dev/null); then
+      printf '%s\n' "$converted"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "$path"
+}
+
 if [[ -n "${LOCALAPPDATA:-}" ]]; then
-  CACHE_DIR="${LOCALAPPDATA}/gga/cache"
+  CACHE_DIR="$(normalize_bash_path "$LOCALAPPDATA")/gga/cache"
 elif [[ -n "${XDG_CACHE_HOME:-}" ]]; then
-  CACHE_DIR="${XDG_CACHE_HOME}/gga"
+  CACHE_DIR="$(normalize_bash_path "$XDG_CACHE_HOME")/gga"
 else
   CACHE_DIR="$HOME/.cache/gga"
 fi

--- a/spec/integration/commands_spec.sh
+++ b/spec/integration/commands_spec.sh
@@ -61,6 +61,12 @@ Describe 'gga commands'
       The output should include "--ci"
       The output should include "CI mode"
     End
+
+    It 'renders configuration paths without literal ANSI escapes'
+      When call gga help
+      The output should include ".gga"
+      The output should not include "\\033"
+    End
   End
 
   Describe 'gga init'
@@ -117,9 +123,12 @@ Describe 'gga commands'
       ORIGINAL_HOME="${HOME:-}"
       ORIGINAL_XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-}"
       ORIGINAL_APPDATA="${APPDATA:-}"
+      ORIGINAL_PATH="$PATH"
+      TEST_BIN_DIR=$(mktemp -d)
       ORIGINAL_GGA_OPENCODE_VARIANT="${GGA_OPENCODE_VARIANT:-}"
       ORIGINAL_GGA_OPENCODE_AGENT="${GGA_OPENCODE_AGENT:-}"
       HOME="$TEST_HOME"
+      PATH="$TEST_BIN_DIR:$PATH"
       XDG_CONFIG_HOME="$TEST_HOME/.config"
       unset APPDATA
       unset GGA_OPENCODE_VARIANT
@@ -140,6 +149,7 @@ Describe 'gga commands'
       else
         unset APPDATA
       fi
+      PATH="$ORIGINAL_PATH"
       if [[ -n "$ORIGINAL_GGA_OPENCODE_VARIANT" ]]; then
         GGA_OPENCODE_VARIANT="$ORIGINAL_GGA_OPENCODE_VARIANT"
       else
@@ -150,7 +160,7 @@ Describe 'gga commands'
       else
         unset GGA_OPENCODE_AGENT
       fi
-      rm -rf "$TEMP_DIR" "$TEST_HOME"
+      rm -rf "$TEMP_DIR" "$TEST_HOME" "$TEST_BIN_DIR"
     }
 
     BeforeEach 'setup'
@@ -170,6 +180,37 @@ Describe 'gga commands'
     It 'shows provider when configured'
       echo 'PROVIDER="claude"' > .gga
       When call gga config
+      The output should include "claude"
+    End
+
+    It 'loads project config with CRLF line endings'
+      printf 'PROVIDER="claude"\r\nFILE_PATTERNS="*.sh"\r\n' > .gga
+      When call gga config
+      The status should be success
+      The output should include "claude"
+      The output should include "*.sh"
+    End
+
+    It 'loads project config with UTF-8 BOM'
+      printf '\357\273\277PROVIDER="claude"\n' > .gga
+      When call gga config
+      The status should be success
+      The output should include "claude"
+    End
+
+    It 'loads global config from Windows-style APPDATA path in Git Bash'
+      mkdir -p "$TEST_BIN_DIR" "$TEST_HOME/AppData/Roaming/gga"
+      cat > "$TEST_BIN_DIR/cygpath" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "-u" ]]; then
+  echo "$TEST_HOME/AppData/Roaming"
+fi
+EOF
+      chmod +x "$TEST_BIN_DIR/cygpath"
+      printf 'PROVIDER="claude"\r\n' > "$TEST_HOME/AppData/Roaming/gga/config"
+
+      When call env APPDATA='C:\Users\Test\AppData\Roaming' TEST_HOME="$TEST_HOME" PATH="$PATH" "$PROJECT_ROOT/bin/gga" config
+      The status should be success
       The output should include "claude"
     End
 
@@ -230,6 +271,23 @@ EOF
     It 'hook contains gga run command'
       gga install > /dev/null
       The contents of file ".git/hooks/pre-commit" should include "gga run"
+    End
+
+    It 'resolves sibling lib/gga directory when installed LIB_DIR is stale'
+      local install_root
+      install_root=$(mktemp -d)
+      mkdir -p "$install_root/bin/lib/gga"
+      cp "$PROJECT_ROOT/bin/gga" "$install_root/bin/gga"
+      cp "$PROJECT_ROOT/lib/providers.sh" "$install_root/bin/lib/gga/providers.sh"
+      cp "$PROJECT_ROOT/lib/cache.sh" "$install_root/bin/lib/gga/cache.sh"
+      cp "$PROJECT_ROOT/lib/pr_mode.sh" "$install_root/bin/lib/gga/pr_mode.sh"
+      sed -i.bak 's|^LIB_DIR=.*|LIB_DIR="/mnt/c/Users/example/bin/lib/gga"|' "$install_root/bin/gga"
+      chmod +x "$install_root/bin/gga"
+
+      When call "$install_root/bin/gga" version
+      The status should be success
+      The output should include "gga v"
+      rm -rf "$install_root"
     End
 
     It 'hook is executable'

--- a/spec/unit/cache_spec.sh
+++ b/spec/unit/cache_spec.sh
@@ -3,6 +3,32 @@
 Describe 'cache.sh'
   Include "$LIB_DIR/cache.sh"
 
+  Describe 'normalize_bash_path()'
+    It 'converts Windows paths with cygpath when available'
+      cygpath() {
+        [[ "$1" == "-u" ]] || return 1
+        echo "/c/Users/Test/AppData/Local"
+      }
+
+      When call normalize_bash_path 'C:\Users\Test\AppData\Local'
+      The output should eq "/c/Users/Test/AppData/Local"
+    End
+
+    It 'falls back to the original path when cygpath fails'
+      cygpath() {
+        return 1
+      }
+
+      When call normalize_bash_path 'C:\Bad\Path'
+      The output should eq 'C:\Bad\Path'
+    End
+
+    It 'leaves POSIX paths unchanged'
+      When call normalize_bash_path "/tmp/cache"
+      The output should eq "/tmp/cache"
+    End
+  End
+
   Describe 'get_file_hash()'
     setup() {
       TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
## Summary
Fix Windows/Git Bash path and config-loading failures reported across multiple issues.

## Changes
- Normalize Windows-style `APPDATA`, `XDG_CONFIG_HOME`, and `LOCALAPPDATA` paths through `cygpath` when running under Bash.
- Gracefully fall back to the original path if `cygpath` is unavailable or fails.
- Load `.gga` and global config through a sanitized stream so CRLF line endings and UTF-8 BOM do not break `source`.
- Add installed-script library resolution fallbacks for stale or mixed Windows/WSL `LIB_DIR` paths.
- Render help configuration paths with `echo -e` so ANSI colors do not print as literal `\033` text.
- Add regression coverage for CRLF/BOM configs, Windows-style global config paths, stale `LIB_DIR` fallback, help rendering, and cache path normalization.

## Testing
- `shellspec spec/integration/commands_spec.sh spec/unit/cache_spec.sh`
- `make lint`
- Fresh review:
  - `review-reliability`: No findings
  - `review-resilience`: No findings

Closes #94
Closes #91
Closes #75
Closes #64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Windows-style paths for config, cache, and install locations.
  * Config files now load more reliably when they include UTF-8 BOMs or CRLF line endings.
  * Help output now renders configuration path details correctly without showing raw escape sequences.
  * Installed commands are more resilient if the library location has moved or is outdated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->