### PR TITLE
feat(providers): add Kiro CLI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <strong>Provider-agnostic code review using AI</strong><br>
-  Use Claude, Gemini, Codex, OpenCode, Cursor Agent, Kilo, Ollama, LM Studio, GitHub Models, MiniMax, or any AI to enforce your coding standards.<br>
+  Use Claude, Gemini, Codex, OpenCode, Cursor Agent, Kilo, Kiro, Ollama, LM Studio, GitHub Models, MiniMax, or any AI to enforce your coding standards.<br>
   Pure Bash core. Works everywhere.
 </p>
 
@@ -45,7 +45,7 @@ You have coding standards. Your team ignores them. Code reviews catch issues too
 └─────────────────┘     └──────────────┘     └─────────────────┘
 ```
 
-- 🔌 **Provider agnostic** — Claude, Gemini, Codex, OpenCode, Cursor Agent, Kilo, Ollama, LM Studio, GitHub Models, MiniMax
+- 🔌 **Provider agnostic** — Claude, Gemini, Codex, OpenCode, Cursor Agent, Kilo, Kiro, Ollama, LM Studio, GitHub Models, MiniMax
 - 📦 **Pure Bash core** — no runtime framework; individual providers may require their own CLI or API tooling
 - 🪝 **Git native** — Standard pre-commit hook
 - ⚡ **Smart caching** — Skip unchanged files
@@ -124,6 +124,7 @@ gga install             # Install git hook
 | **OpenCode** | `opencode` | [opencode.ai](https://opencode.ai) |
 | **Cursor Agent** | `cursor[:model]` | [cursor.com](https://cursor.com) |
 | **Kilo** | `kilo[:model]` | `npm install -g @kilocode/cli` |
+| **Kiro** | `kiro` | [kiro.dev/downloads](https://kiro.dev/downloads/) |
 | **Ollama** | `ollama:<model>` | [ollama.ai](https://ollama.ai) |
 | **LM Studio** | `lmstudio[:model]` | [lmstudio.ai](https://lmstudio.ai) |
 | **GitHub Models** | `github:<model>` | [marketplace/models](https://github.com/marketplace/models) |

--- a/bin/gga
+++ b/bin/gga
@@ -209,7 +209,7 @@ print_help() {
   echo ""
   echo -e "${BOLD}CONFIG OPTIONS:${NC}"
   echo "  PROVIDER           AI provider to use (required)"
-  echo "                     Values: claude, gemini, codex, opencode, cursor[:model], kilo[:model], ollama:<model>, lmstudio[:model], github:<model>, minimax[:model]"
+  echo "                     Values: claude, gemini, codex, opencode, cursor[:model], kilo[:model], kiro, ollama:<model>, lmstudio[:model], github:<model>, minimax[:model]"
   echo "  FILE_PATTERNS      File patterns to review (default: *)"
   echo "                     Example: *.ts,*.tsx,*.js,*.jsx"
   echo "  EXCLUDE_PATTERNS   Patterns to exclude from review"
@@ -403,7 +403,7 @@ cmd_init() {
 # https://github.com/your-org/gga
 
 # AI Provider (required)
-# Options: claude, gemini, codex, opencode, cursor[:model], kilo[:model], ollama:<model>, lmstudio[:model], github:<model>, minimax[:model]
+# Options: claude, gemini, codex, opencode, cursor[:model], kilo[:model], kiro, ollama:<model>, lmstudio[:model], github:<model>, minimax[:model]
 # Examples:
 #   PROVIDER="claude"
 #   PROVIDER="gemini"
@@ -414,6 +414,7 @@ cmd_init() {
 #   PROVIDER="cursor:composer-2"
 #   PROVIDER="kilo"
 #   PROVIDER="kilo:anthropic/claude-sonnet-4-5"
+#   PROVIDER="kiro"
 #   PROVIDER="ollama:llama3.2"
 #   PROVIDER="ollama:codellama"
 #   PROVIDER="lmstudio"

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -20,6 +20,7 @@ Use whichever AI CLI you have installed:
 | **OpenCode**      | `opencode`         | `echo "prompt" \| opencode run`   | [opencode.ai](https://opencode.ai)                                                 |
 | **Cursor Agent**  | `cursor[:model]`   | `echo "prompt" \| cursor-agent -p --output-format text` | [cursor.com](https://cursor.com)                                      |
 | **Kilo**          | `kilo[:model]`     | `echo "prompt" \| kilo run --auto` | `npm install -g @kilocode/cli`                                                     |
+| **Kiro**          | `kiro`             | `cat prompt.txt \| kiro-cli chat --no-interactive "Review stdin"` | [kiro.dev/downloads](https://kiro.dev/downloads/)                    |
 | **Ollama**        | `ollama:<model>`   | `ollama run <model> "prompt"`     | [ollama.ai](https://ollama.ai)                                                     |
 | **LM Studio**     | `lmstudio[:model]` | HTTP API call to local server     | [lmstudio.ai](https://lmstudio.ai)                                                 |
 | **GitHub Models** | `github:<model>`   | HTTP API via `gh auth token`      | [github.com/marketplace/models](https://github.com/marketplace/models)              |
@@ -56,6 +57,9 @@ PROVIDER="kilo"
 
 # Use Kilo with specific model
 PROVIDER="kilo:anthropic/claude-sonnet-4-5"
+
+# Use Kiro CLI
+PROVIDER="kiro"
 
 # Use Ollama with Llama 3.2
 PROVIDER="ollama:llama3.2"
@@ -150,6 +154,20 @@ npm install -g @kilocode/cli
 # Test it works
 printf 'Say hello' | kilo run --auto
 ```
+
+### Kiro
+
+Uses Kiro CLI in headless mode. GGA sends the review prompt through stdin to avoid ARG_MAX failures on large reviews.
+
+```bash
+# Install Kiro CLI
+# See https://kiro.dev/downloads/
+
+# Test it works
+printf 'Say hello' | kiro-cli chat --no-interactive 'Respond to the stdin prompt'
+```
+
+Kiro headless mode requires a small positional prompt, so GGA passes a short instruction in argv and sends the full review prompt through stdin. Kiro model selection is managed through Kiro CLI settings, not inline `PROVIDER="kiro:model"` config.
 
 ### MiniMax
 

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -10,6 +10,7 @@
 # - opencode: OpenCode CLI (optional :model)
 # - cursor: Cursor Agent CLI (optional :model)
 # - kilo: Kilo CLI (optional :model)
+# - kiro: Kiro CLI
 # - ollama:<model>: Ollama with specified model
 # - lmstudio[:model]: LM Studio (optional model)
 # - github:<model>: GitHub Models (OpenAI-compatible API)
@@ -89,6 +90,24 @@ validate_provider() {
         echo ""
         echo "Install Kilo CLI:"
         echo "  npm install -g @kilocode/cli"
+        echo ""
+        return 1
+      fi
+      ;;
+    kiro)
+      if ! command -v kiro-cli &> /dev/null; then
+        echo -e "${RED}❌ Kiro CLI not found${NC}"
+        echo ""
+        echo "Install Kiro CLI:"
+        echo "  https://kiro.dev/downloads/"
+        echo ""
+        return 1
+      fi
+      local model="${provider#*:}"
+      if [[ "$model" != "$provider" && -n "$model" ]]; then
+        echo -e "${RED}❌ Kiro provider does not support inline model selection${NC}"
+        echo ""
+        echo "Configure Kiro's default model with kiro-cli settings instead."
         echo ""
         return 1
       fi
@@ -210,6 +229,7 @@ validate_provider() {
       echo "  - opencode"
       echo "  - cursor[:model]"
       echo "  - kilo[:model]"
+      echo "  - kiro"
       echo "  - ollama:<model>"
       echo "  - lmstudio[:model]"
       echo "  - github:<model>"
@@ -261,6 +281,9 @@ execute_provider() {
         model=""
       fi
       execute_kilo "$model" "$prompt"
+      ;;
+    kiro)
+      execute_kiro "$prompt"
       ;;
     ollama)
       local model="${provider#*:}"
@@ -419,6 +442,16 @@ execute_kilo() {
   else
     printf '%s' "$prompt" | kilo run --auto 2>&1
   fi
+  return "${PIPESTATUS[1]}"
+}
+
+execute_kiro() {
+  local prompt="$1"
+  local kiro_instruction="Review the complete GGA prompt provided on stdin and respond with the required STATUS line."
+
+  # Kiro headless mode requires a small positional prompt. The large review
+  # prompt travels through stdin as context to avoid ARG_MAX failures.
+  printf '%s' "$prompt" | kiro-cli chat --no-interactive "$kiro_instruction" 2>&1
   return "${PIPESTATUS[1]}"
 }
 
@@ -954,6 +987,9 @@ get_provider_info() {
         echo "Kilo CLI (model: $model)"
       fi
       ;;
+    kiro)
+      echo "Kiro CLI"
+      ;;
     ollama)
       local model="${provider#*:}"
       echo "Ollama (model: $model)"
@@ -1137,7 +1173,7 @@ execute_with_timeout() {
 # Execute provider with timeout and progress feedback
 # Usage: execute_provider_with_timeout <provider> <prompt> <timeout>
 #
-# For CLI providers (claude, gemini, codex, opencode, cursor, kilo), the prompt is written to a
+# For CLI providers (claude, gemini, codex, opencode, cursor, kilo, kiro), the prompt is written to a
 # temp file and piped via stdin to avoid ARG_MAX limits on Windows (~8KB-32KB),
 # macOS (~256KB), and Linux (~128KB-2MB). Only the file path (short string) is
 # passed as an argument to execute_with_timeout, never the prompt content.
@@ -1149,7 +1185,7 @@ execute_provider_with_timeout() {
   local result=0
 
   case "$base_provider" in
-    claude|gemini|codex|opencode|cursor|kilo)
+    claude|gemini|codex|opencode|cursor|kilo|kiro)
       # Write prompt to temp file ONCE to avoid ARG_MAX limits.
       # This is critical for large PRs that generate prompts > 128KB-256KB.
       # Only CLI providers are handled here. API-based providers keep their
@@ -1268,6 +1304,14 @@ execute_provider_with_timeout() {
             execute_with_timeout "$timeout" "Kilo" \
               bash -c 'exec kilo run --auto < "$1"' _ "$prompt_file"
           fi
+          result=$?
+          ;;
+        kiro)
+          # Kiro headless mode requires a small positional prompt. The large
+          # review prompt travels through stdin as context to avoid ARG_MAX.
+          # shellcheck disable=SC2016
+          execute_with_timeout "$timeout" "Kiro" \
+            bash -c 'exec kiro-cli chat --no-interactive "$2" < "$1"' _ "$prompt_file" "Review the complete GGA prompt provided on stdin and respond with the required STATUS line."
           result=$?
           ;;
       esac

--- a/spec/unit/providers_argmax_behavior_spec.sh
+++ b/spec/unit/providers_argmax_behavior_spec.sh
@@ -112,7 +112,22 @@ fi
 cat
 FAKE
 
-    chmod +x "$TEST_BIN_DIR/claude" "$TEST_BIN_DIR/gemini" "$TEST_BIN_DIR/codex" "$TEST_BIN_DIR/opencode" "$TEST_BIN_DIR/cursor-agent" "$TEST_BIN_DIR/kilo"
+    cat > "$TEST_BIN_DIR/kiro-cli" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" != "chat" || "$2" != "--no-interactive" ]]; then
+  echo "unexpected kiro args: $*" >&2
+  exit 64
+fi
+shift 2
+if [[ $# -ne 1 ]]; then
+  echo "missing kiro headless instruction: $*" >&2
+  exit 64
+fi
+echo "KIRO_INSTRUCTION:$1"
+cat
+FAKE
+
+    chmod +x "$TEST_BIN_DIR/claude" "$TEST_BIN_DIR/gemini" "$TEST_BIN_DIR/codex" "$TEST_BIN_DIR/opencode" "$TEST_BIN_DIR/cursor-agent" "$TEST_BIN_DIR/kilo" "$TEST_BIN_DIR/kiro-cli"
   }
   BeforeEach 'setup'
 
@@ -200,6 +215,15 @@ FAKE
     The output should include "line 1"
     The output should include "line 2"
     The stderr should include "Waiting for Kilo"
+  End
+
+  It 'passes the full prompt to kiro via stdin with only a small instruction arg'
+    When call execute_provider_with_timeout "kiro" $'line 1\nline 2' 5
+    The status should be success
+    The output should include "KIRO_INSTRUCTION:Review the complete GGA prompt provided on stdin"
+    The output should include "line 1"
+    The output should include "line 2"
+    The stderr should include "Waiting for Kiro"
   End
 
   It 'passes opencode variant and agent flags while keeping prompt on stdin'

--- a/spec/unit/providers_argmax_spec.sh
+++ b/spec/unit/providers_argmax_spec.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 
 # Tests for ARG_MAX fix - execute_provider_with_timeout should handle large prompts
-# via temp files for CLI providers (claude, gemini, codex, opencode, cursor, kilo).
+# via temp files for CLI providers (claude, gemini, codex, opencode, cursor, kilo, kiro).
 # Related issues: #77 (macOS), #87 (Windows), #58, #85
 
 Describe 'providers.sh ARG_MAX handling'
@@ -26,6 +26,7 @@ Describe 'providers.sh ARG_MAX handling'
     opencode() { cat; }
     gemini() { cat; }
     kilo() { cat; }
+    kiro-cli() { cat; }
 
     It 'writes prompt to temp file for claude'
       When call execute_provider_with_timeout "claude" "test prompt" 300
@@ -69,6 +70,13 @@ Describe 'providers.sh ARG_MAX handling'
       The output should include "TIMEOUT:300:Kilo"
       The output should include "bash -c"
       The output should include "kilo run --auto"
+    End
+
+    It 'writes prompt to temp file for kiro'
+      When call execute_provider_with_timeout "kiro" "test prompt" 300
+      The output should include "TIMEOUT:300:Kiro"
+      The output should include "bash -c"
+      The output should include "kiro-cli chat --no-interactive"
     End
 
     It 'handles large prompts without ARG_MAX errors'

--- a/spec/unit/providers_kiro_spec.sh
+++ b/spec/unit/providers_kiro_spec.sh
@@ -1,0 +1,65 @@
+# shellcheck shell=bash
+
+Describe 'providers.sh kiro support'
+  Include "$LIB_DIR/providers.sh"
+
+  Describe 'get_provider_info()'
+    It 'returns info for kiro'
+      When call get_provider_info "kiro"
+      The output should include "Kiro CLI"
+    End
+  End
+
+  Describe 'execute_kiro()'
+    kiro-cli() {
+      if [[ "$1" != "chat" || "$2" != "--no-interactive" ]]; then
+        echo "unexpected kiro args: $*" >&2
+        return 64
+      fi
+      shift 2
+      if [[ $# -ne 1 ]]; then
+        echo "missing kiro headless instruction: $*" >&2
+        return 64
+      fi
+      echo "INSTRUCTION:$1"
+      cat
+    }
+
+    It 'executes kiro with prompt through stdin and a small headless instruction'
+      When call execute_kiro "test prompt"
+      The status should be success
+      The output should include "INSTRUCTION:Review the complete GGA prompt provided on stdin"
+      The output should include "test prompt"
+    End
+  End
+
+  Describe 'validate_provider() - kiro'
+    It 'succeeds when kiro CLI is available'
+      kiro-cli() { return 0; }
+
+      When call validate_provider "kiro"
+      The status should be success
+    End
+
+    It 'fails when kiro CLI is unavailable'
+      command() {
+        case "$2" in
+          kiro-cli) return 1 ;;
+          *) builtin command "$@" ;;
+        esac
+      }
+
+      When call validate_provider "kiro"
+      The status should be failure
+      The output should include "Kiro CLI not found"
+    End
+
+    It 'rejects inline model selection'
+      kiro-cli() { return 0; }
+
+      When call validate_provider "kiro:claude-sonnet-4"
+      The status should be failure
+      The output should include "does not support inline model selection"
+    End
+  End
+End


### PR DESCRIPTION
## Summary

Adds first-class Kiro CLI provider support as `PROVIDER="kiro"`.

## Changes

- Adds `kiro` provider validation and execution through `kiro-cli chat --no-interactive`.
- Keeps the full GGA review prompt out of argv by sending it through stdin/temp-file handoff.
- Uses a short required headless instruction as Kiro's positional prompt.
- Rejects `kiro:model` with guidance because Kiro CLI model selection is managed through Kiro settings.
- Updates CLI help, README, and provider docs.
- Adds provider, validation, and ARG_MAX tests for Kiro.

## Testing

- [x] `shellspec spec/unit/providers_kiro_spec.sh spec/unit/providers_argmax_behavior_spec.sh spec/unit/providers_argmax_spec.sh spec/integration/commands_spec.sh`
- [x] `make lint`
- [ ] `make test` local full suite: one unrelated local-only OpenCode integration test failed for `execute_opencode "anthropic/claude-sonnet-4"`; Kiro-targeted tests passed and CI should skip unavailable local OpenCode integration.

## Review evidence

- Fresh `review-reliability`: no findings after correction.
- Fresh `review-resilience`: no findings after correction.

Closes #102


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the **Kiro** AI provider.
  * Kiro now appears in help output and config examples, with guidance for headless use.

* **Documentation**
  * Updated provider docs and README to include Kiro in the supported provider list.
  * Added Kiro usage notes, including prompt input behavior and setup details.

* **Bug Fixes**
  * Improved provider validation to give clearer errors when Kiro is unavailable or configured with unsupported inline model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->