### PR TITLE
fix(config): preserve provider while stripping CRLF

### DIFF
--- a/bin/gga
+++ b/bin/gga
@@ -270,7 +270,24 @@ sanitize_config_file() {
 
   # Strip UTF-8 BOM from the first line and CR from CRLF files before sourcing.
   # This keeps Windows-edited .gga files readable without modifying user files.
-  sed $'1s/^\xef\xbb\xbf//' "$config_file" | tr -d '\r'
+  sed $'1s/^\xef\xbb\xbf//' "$config_file" | tr -d '\015'
+}
+
+source_config_file() {
+  local config_file="$1"
+  local sanitized_config
+
+  sanitized_config=$(mktemp "${TMPDIR:-/tmp}/gga-config.XXXXXX")
+  sanitize_config_file "$config_file" > "$sanitized_config"
+
+  # shellcheck source=/dev/null
+  if source "$sanitized_config"; then
+    rm -f "$sanitized_config"
+    return 0
+  fi
+
+  rm -f "$sanitized_config"
+  return 1
 }
 
 load_config() {
@@ -288,15 +305,13 @@ load_config() {
   # Load global config first (platform-aware path)
   GLOBAL_CONFIG=$(get_global_config_path)
   if [[ -f "$GLOBAL_CONFIG" ]]; then
-    # shellcheck source=/dev/null
-    source <(sanitize_config_file "$GLOBAL_CONFIG")
+    source_config_file "$GLOBAL_CONFIG"
   fi
 
   # Load project config (overrides global)
   PROJECT_CONFIG=".gga"
   if [[ -f "$PROJECT_CONFIG" ]]; then
-    # shellcheck source=/dev/null
-    source <(sanitize_config_file "$PROJECT_CONFIG")
+    source_config_file "$PROJECT_CONFIG"
   fi
 
   # Environment variable overrides everything

--- a/bin/gga
+++ b/bin/gga
@@ -277,8 +277,14 @@ source_config_file() {
   local config_file="$1"
   local sanitized_config
 
-  sanitized_config=$(mktemp "${TMPDIR:-/tmp}/gga-config.XXXXXX")
-  sanitize_config_file "$config_file" > "$sanitized_config"
+  if ! sanitized_config=$(mktemp "${TMPDIR:-/tmp}/gga-config.XXXXXX"); then
+    return 1
+  fi
+
+  if ! sanitize_config_file "$config_file" > "$sanitized_config"; then
+    rm -f "$sanitized_config"
+    return 1
+  fi
 
   # shellcheck source=/dev/null
   if source "$sanitized_config"; then

--- a/bin/gga
+++ b/bin/gga
@@ -270,7 +270,7 @@ sanitize_config_file() {
 
   # Strip UTF-8 BOM from the first line and CR from CRLF files before sourcing.
   # This keeps Windows-edited .gga files readable without modifying user files.
-  sed $'1s/^\xef\xbb\xbf//' "$config_file" | tr -d '\015'
+  (set -o pipefail; sed $'1s/^\xef\xbb\xbf//' "$config_file" | tr -d '\015')
 }
 
 source_config_file() {

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -598,6 +598,24 @@ validate_lmstudio_host() {
   return 1
 }
 
+report_lmstudio_request_failure() {
+  local endpoint="$1"
+  local curl_status="$2"
+  local http_status="$3"
+  local response_body="$4"
+
+  echo "Error: LM Studio request failed at $endpoint" >&2
+  echo "curl exit code: $curl_status" >&2
+  if [[ -n "$http_status" ]]; then
+    echo "HTTP status: $http_status" >&2
+  else
+    echo "HTTP status: unknown" >&2
+  fi
+  if [[ -n "$response_body" ]]; then
+    echo "$response_body" >&2
+  fi
+}
+
 execute_lmstudio_api() {
   local model="$1"
   local prompt="$2"
@@ -634,16 +652,24 @@ print(payload)
 
   # Call LM Studio API. Send the payload through stdin so large prompts do not
   # travel through argv and hit ARG_MAX on Git Bash/MSYS or macOS.
-  local api_response
-  api_response=$(printf '%s' "$json_payload" | curl -s --fail-with-body \
+  local curl_output
+  curl_output=$(printf '%s' "$json_payload" | curl -sS --fail-with-body \
     -H "Content-Type: application/json" \
     --data-binary @- \
+    -w $'\n__GGA_HTTP_STATUS:%{http_code}' \
     "$endpoint" 2>&1)
 
   local curl_status=$?
+  local api_response="$curl_output"
+  local http_status=""
+  local status_marker=$'\n__GGA_HTTP_STATUS:'
+  if [[ "$curl_output" == *"$status_marker"* ]]; then
+    http_status="${curl_output##*"$status_marker"}"
+    api_response="${curl_output%%"$status_marker"*}"
+  fi
+
   if [[ $curl_status -ne 0 ]]; then
-    echo "Error: Failed to connect to LM Studio at $host" >&2
-    echo "$api_response" >&2
+    report_lmstudio_request_failure "$endpoint" "$curl_status" "$http_status" "$api_response"
     return 1
   fi
 
@@ -709,16 +735,24 @@ execute_lmstudio_api_fallback() {
 
   # Call LM Studio API. Send the payload through stdin so large prompts do not
   # travel through argv and hit ARG_MAX on Git Bash/MSYS or macOS.
-  local api_response
-  api_response=$(printf '%s' "$json_payload" | curl -s --fail-with-body \
+  local curl_output
+  curl_output=$(printf '%s' "$json_payload" | curl -sS --fail-with-body \
     -H "Content-Type: application/json" \
     --data-binary @- \
+    -w $'\n__GGA_HTTP_STATUS:%{http_code}' \
     "$endpoint" 2>&1)
 
   local curl_status=$?
+  local api_response="$curl_output"
+  local http_status=""
+  local status_marker=$'\n__GGA_HTTP_STATUS:'
+  if [[ "$curl_output" == *"$status_marker"* ]]; then
+    http_status="${curl_output##*"$status_marker"}"
+    api_response="${curl_output%%"$status_marker"*}"
+  fi
+
   if [[ $curl_status -ne 0 ]]; then
-    echo "Error: Failed to connect to LM Studio at $host" >&2
-    echo "$api_response" >&2
+    report_lmstudio_request_failure "$endpoint" "$curl_status" "$http_status" "$api_response"
     return 1
   fi
 

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -616,6 +616,37 @@ report_lmstudio_request_failure() {
   fi
 }
 
+call_lmstudio_curl() {
+  local endpoint="$1"
+  local json_payload="$2"
+  local curl_output
+  local curl_status
+  local status_marker=$'\n__GGA_HTTP_STATUS:'
+
+  LMSTUDIO_CURL_RESPONSE=""
+  LMSTUDIO_CURL_HTTP_STATUS=""
+
+  curl_output=$(printf '%s' "$json_payload" | curl -sS --fail-with-body \
+    -H "Content-Type: application/json" \
+    --data-binary @- \
+    -w $'\n__GGA_HTTP_STATUS:%{http_code}' \
+    "$endpoint" 2>&1)
+  curl_status=$?
+
+  LMSTUDIO_CURL_RESPONSE="$curl_output"
+  if [[ "$curl_output" == *"$status_marker"* ]]; then
+    LMSTUDIO_CURL_HTTP_STATUS="${curl_output##*"$status_marker"}"
+    LMSTUDIO_CURL_RESPONSE="${curl_output%%"$status_marker"*}"
+  fi
+
+  if [[ $curl_status -ne 0 ]]; then
+    report_lmstudio_request_failure "$endpoint" "$curl_status" "$LMSTUDIO_CURL_HTTP_STATUS" "$LMSTUDIO_CURL_RESPONSE"
+    return 1
+  fi
+
+  return 0
+}
+
 execute_lmstudio_api() {
   local model="$1"
   local prompt="$2"
@@ -650,28 +681,10 @@ print(payload)
 
   local endpoint="${host}/chat/completions"
 
-  # Call LM Studio API. Send the payload through stdin so large prompts do not
-  # travel through argv and hit ARG_MAX on Git Bash/MSYS or macOS.
-  local curl_output
-  curl_output=$(printf '%s' "$json_payload" | curl -sS --fail-with-body \
-    -H "Content-Type: application/json" \
-    --data-binary @- \
-    -w $'\n__GGA_HTTP_STATUS:%{http_code}' \
-    "$endpoint" 2>&1)
-
-  local curl_status=$?
-  local api_response="$curl_output"
-  local http_status=""
-  local status_marker=$'\n__GGA_HTTP_STATUS:'
-  if [[ "$curl_output" == *"$status_marker"* ]]; then
-    http_status="${curl_output##*"$status_marker"}"
-    api_response="${curl_output%%"$status_marker"*}"
-  fi
-
-  if [[ $curl_status -ne 0 ]]; then
-    report_lmstudio_request_failure "$endpoint" "$curl_status" "$http_status" "$api_response"
+  if ! call_lmstudio_curl "$endpoint" "$json_payload"; then
     return 1
   fi
+  local api_response="$LMSTUDIO_CURL_RESPONSE"
 
   # Extract response
   printf '%s' "$api_response" | python3 -c "
@@ -733,28 +746,10 @@ execute_lmstudio_api_fallback() {
 
   local endpoint="${host}/chat/completions"
 
-  # Call LM Studio API. Send the payload through stdin so large prompts do not
-  # travel through argv and hit ARG_MAX on Git Bash/MSYS or macOS.
-  local curl_output
-  curl_output=$(printf '%s' "$json_payload" | curl -sS --fail-with-body \
-    -H "Content-Type: application/json" \
-    --data-binary @- \
-    -w $'\n__GGA_HTTP_STATUS:%{http_code}' \
-    "$endpoint" 2>&1)
-
-  local curl_status=$?
-  local api_response="$curl_output"
-  local http_status=""
-  local status_marker=$'\n__GGA_HTTP_STATUS:'
-  if [[ "$curl_output" == *"$status_marker"* ]]; then
-    http_status="${curl_output##*"$status_marker"}"
-    api_response="${curl_output%%"$status_marker"*}"
-  fi
-
-  if [[ $curl_status -ne 0 ]]; then
-    report_lmstudio_request_failure "$endpoint" "$curl_status" "$http_status" "$api_response"
+  if ! call_lmstudio_curl "$endpoint" "$json_payload"; then
     return 1
   fi
+  local api_response="$LMSTUDIO_CURL_RESPONSE"
 
   # Extract response using sed/grep
   printf '%s' "$api_response" | sed -n 's/.*"content":"\([^"]*\)".*/\1/p' | sed 's/\\n/\n/g; s/\\"/"/g'

--- a/spec/integration/commands_spec.sh
+++ b/spec/integration/commands_spec.sh
@@ -183,6 +183,23 @@ Describe 'gga commands'
       The output should include "claude"
     End
 
+    Describe 'CRLF provider parsing'
+      Parameters
+        "lmstudio"
+        "lmstudio:qwen/qwen3.5-9b"
+        "minimax:MiniMax-M3"
+      End
+
+      It 'preserves provider variable name and value while stripping CRLF characters'
+        printf 'PROVIDER="%s"\r\nFILE_PATTERNS="*.sh"\r\n' "$1" > .gga
+        When call gga config
+        The status should be success
+        The output should include "PROVIDER:"
+        The output should include "$1"
+        The output should include "*.sh"
+      End
+    End
+
     It 'loads project config with CRLF line endings'
       printf 'PROVIDER="claude"\r\nFILE_PATTERNS="*.sh"\r\n' > .gga
       When call gga config

--- a/spec/integration/commands_spec.sh
+++ b/spec/integration/commands_spec.sh
@@ -208,6 +208,23 @@ Describe 'gga commands'
       The output should include "*.sh"
     End
 
+    It 'fails cleanly when temporary config creation fails'
+      echo 'PROVIDER="claude"' > .gga
+      cat > "$TEST_BIN_DIR/mktemp" <<'EOF'
+#!/usr/bin/env bash
+echo "mktemp failed" >&2
+exit 1
+EOF
+      chmod +x "$TEST_BIN_DIR/mktemp"
+
+      When call gga config
+      The status should be failure
+      The output should include "Gentleman Guardian Angel"
+      The stderr should include "mktemp failed"
+      The stderr should not include "No such file or directory"
+      The stderr should not include "source:"
+    End
+
     It 'loads project config with UTF-8 BOM'
       printf '\357\273\277PROVIDER="claude"\n' > .gga
       When call gga config

--- a/spec/integration/commands_spec.sh
+++ b/spec/integration/commands_spec.sh
@@ -225,6 +225,23 @@ EOF
       The stderr should not include "source:"
     End
 
+    It 'fails cleanly when config sanitization fails'
+      echo 'PROVIDER="claude"' > .gga
+      cat > "$TEST_BIN_DIR/sed" <<'EOF'
+#!/usr/bin/env bash
+echo "sed failed" >&2
+exit 1
+EOF
+      chmod +x "$TEST_BIN_DIR/sed"
+
+      When call gga config
+      The status should be failure
+      The output should include "Gentleman Guardian Angel"
+      The output should not include "Not configured"
+      The stderr should include "sed failed"
+      The stderr should not include "source:"
+    End
+
     It 'loads project config with UTF-8 BOM'
       printf '\357\273\277PROVIDER="claude"\n' > .gga
       When call gga config

--- a/spec/unit/providers_spec.sh
+++ b/spec/unit/providers_spec.sh
@@ -444,12 +444,31 @@ All good!"
     It 'handles curl failure'
       curl() {
         echo "Connection refused"
+        echo "__GGA_HTTP_STATUS:000"
         return 7
       }
 
       When call execute_lmstudio_api "llama-3" "test" "http://localhost:1234/v1"
       The status should be failure
-      The stderr should include "Failed to connect"
+      The stderr should include "LM Studio request failed"
+      The stderr should include "curl exit code: 7"
+      The stderr should include "HTTP status: 000"
+      The stderr should include "Connection refused"
+    End
+
+    It 'reports HTTP errors with status and response body'
+      curl() {
+        echo '{"error":{"message":"context length exceeded"}}'
+        echo "__GGA_HTTP_STATUS:500"
+        return 22
+      }
+
+      When call execute_lmstudio_api "llama-3" "test" "http://localhost:1234/v1"
+      The status should be failure
+      The stderr should include "LM Studio request failed"
+      The stderr should include "curl exit code: 22"
+      The stderr should include "HTTP status: 500"
+      The stderr should include "context length exceeded"
     End
 
     It 'parses JSON response correctly'
@@ -541,6 +560,21 @@ EOF
   End
 
   Describe 'execute_lmstudio_api_fallback()'
+    It 'reports curl failures with status and response body'
+      curl() {
+        echo '{"error":{"message":"server overloaded"}}'
+        echo "__GGA_HTTP_STATUS:503"
+        return 22
+      }
+
+      When call execute_lmstudio_api_fallback "llama-3" "test" "http://localhost:1234/v1"
+      The status should be failure
+      The stderr should include "LM Studio request failed"
+      The stderr should include "curl exit code: 22"
+      The stderr should include "HTTP status: 503"
+      The stderr should include "server overloaded"
+    End
+
     It 'sends JSON payload through stdin instead of argv'
       curl() {
         local args="$*"


### PR DESCRIPTION
## Linked Issue

Closes #109

## PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature or enhancement
- [ ] `type:docs` — Documentation changes only
- [ ] `type:refactor` — Code refactor (no behavior change)
- [ ] `type:chore` — Maintenance (deps, CI, tooling)
- [ ] `type:breaking-change` — Breaking change (add `!` to commit type)

## Summary

Fixes `.gga` config loading so `PROVIDER` remains configured when project config files use CRLF line endings.

The previous sanitization path could fail to preserve the `PROVIDER` assignment on macOS Bash, causing `gga run` to report `No provider configured` for valid providers such as `lmstudio`, `lmstudio:qwen/qwen3.5-9b`, and `minimax:MiniMax-M3`.

This also improves LM Studio request failure diagnostics so long-running API failures report the endpoint, curl exit code, HTTP status, and response body instead of the generic `Failed to connect` message.

## Changes

| File | Change |
|------|--------|
| `bin/gga` | Replaces process-substitution config sourcing with a sanitized temporary config file, and strips CR characters using `tr -d '\015'`. |
| `lib/providers.sh` | Reports detailed LM Studio request failures with curl exit code, HTTP status, endpoint, and response body. |
| `spec/integration/commands_spec.sh` | Adds parameterized regression coverage for preserving the `PROVIDER` key and exact value with CRLF config files. |
| `spec/unit/providers_spec.sh` | Adds LM Studio failure diagnostics coverage for network and HTTP error responses. |

## Test Plan

- [x] `make lint` (ShellCheck) passes locally
- [ ] `make test` passes locally (all unit tests)
- [x] `shellspec spec/unit/providers_spec.sh` passes
- [x] `shellspec spec/integration/commands_spec.sh` passes
- [x] Manual testing: reproduced `.gga` config loading with CRLF and validated provider values `lmstudio`, `lmstudio:qwen/qwen3.5-9b`, and `minimax:MiniMax-M3`
- [x] Manual testing: ran a small `gga run --no-cache` against LM Studio at `http://100.107.225.97:1234/v1` and received `STATUS: PASSED`

Full `make test` was run locally, but it currently fails on existing OpenCode-related tests in untouched pre-existing provider behavior with `opencode_args[@]: unbound variable`. The focused suites for this PR pass.

## Automated Checks

The following checks run automatically on every PR:

| Check | Validates |
|-------|-----------|
| Check Issue Reference | PR body contains `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | Linked issue was approved by a maintainer |
| Check PR Has `type:*` Label | PR has exactly one `type:*` label |
| Lint | ShellCheck passes on `bin/gga` and `lib/*.sh` |
| Unit Tests | `shellspec spec/unit` passes |
| Integration Tests | `shellspec spec/integration/commands_spec.sh` passes |

## Contributor Checklist

- [x] I have linked the issue above with `Closes #N`
- [ ] The linked issue has `status:approved`
- [ ] I have added a `type:*` label to this PR
- [x] `make lint` passes (ShellCheck)
- [ ] `make test` passes (all unit tests)
- [x] Integration tests pass
- [x] New functions/commands have tests in `spec/`
- [x] I followed conventional commits (`feat:`, `fix:`, `docs:`, etc.)
- [x] I have NOT added "Co-Authored-By" or AI attribution to commits
- [x] Breaking changes are documented and use `!` in the commit type (`feat!:`, `fix!:`)

## Notes for Reviewers

Issue #109 still needs the `status:approved` label from a maintainer before this PR can pass the repository issue-first validation.

The LM Studio diagnostics change intentionally does not change provider execution semantics. It only exposes the curl/HTTP details needed to distinguish network failures from LM Studio API failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved config loading by stripping CR characters and safely sourcing sanitized configs from temporary files (with reliable cleanup).
  * Enhanced LM Studio request failures to report the endpoint, curl exit code, HTTP status (when available), and any response body.
* **Tests**
  * Extended CRLF coverage for provider parsing with new parameterized integration tests and removed a redundant single-case test.
  * Added failure-mode integration tests for temporary config creation and sanitization, and expanded unit assertions for LM Studio curl error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->