### PR TITLE
feat(providers): add provider fallback chain (#128)

### DIFF
--- a/bin/gga
+++ b/bin/gga
@@ -210,6 +210,7 @@ print_help() {
   echo -e "${BOLD}CONFIG OPTIONS:${NC}"
   echo "  PROVIDER           AI provider to use (required)"
   echo "                     Values: claude, gemini, codex, opencode, cursor[:model], kilo[:model], kiro, ollama:<model>, lmstudio[:model], github:<model>, minimax[:model]"
+  echo "                     Comma-separated fallback: PROVIDER=\"claude,gemini,ollama:llama3\""
   echo "  FILE_PATTERNS      File patterns to review (default: *)"
   echo "                     Example: *.ts,*.tsx,*.js,*.jsx"
   echo "  EXCLUDE_PATTERNS   Patterns to exclude from review"
@@ -794,9 +795,22 @@ cmd_run() {
     exit 1
   fi
 
-  # Validate provider is available
-  if ! validate_provider "$PROVIDER"; then
-    exit 1
+  # Validate provider(s) — comma triggers fallback chain
+  if [[ "$PROVIDER" == *","* ]]; then
+    declare -a GGA_CHAIN=()
+    parse_provider_list "$PROVIDER" GGA_CHAIN
+    if [[ ${#GGA_CHAIN[@]} -eq 0 ]]; then
+      log_error "No valid providers in list: $PROVIDER"
+      exit 1
+    fi
+    # Validate first provider upfront (fail fast on obvious misconfigurations)
+    if ! validate_provider "${GGA_CHAIN[0]}"; then
+      exit 1
+    fi
+  else
+    if ! validate_provider "$PROVIDER"; then
+      exit 1
+    fi
   fi
 
   # Check rules file exists
@@ -970,13 +984,21 @@ cmd_run() {
   fi
 
   # Execute review with timeout and progress feedback
-  log_info "Sending to $PROVIDER for review (timeout: ${TIMEOUT}s)..."
+  if [[ "$PROVIDER" == *","* ]]; then
+    log_info "Sending to provider chain [${GGA_CHAIN[*]:-}] for review (timeout: ${TIMEOUT}s)..."
+  else
+    log_info "Sending to $PROVIDER for review (timeout: ${TIMEOUT}s)..."
+  fi
   echo ""
 
   # Temporarily disable set -e to capture exit status properly
   # (bash 3.2 on macOS can exit on non-zero in command substitution)
   set +e
-  RESULT=$(execute_provider_with_timeout "$PROVIDER" "$PROMPT" "$TIMEOUT")
+  if [[ "$PROVIDER" == *","* ]]; then
+    RESULT=$(execute_with_fallback "$PROMPT" "$TIMEOUT" GGA_CHAIN)
+  else
+    RESULT=$(execute_provider_with_timeout "$PROVIDER" "$PROMPT" "$TIMEOUT")
+  fi
   EXEC_STATUS=$?
   set -e
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,11 @@ Create this file in your project root:
 # Options: claude, gemini, codex, opencode, ollama:<model>, lmstudio[:model], github:<model>
 PROVIDER="claude"
 
+# Fallback chain (optional) — comma-separated, tried in order
+# On transient failure (timeout, rate-limit, network), GGA advances to the next provider.
+# On config error (missing API key, auth rejection), GGA aborts immediately.
+PROVIDER="claude,gemini,ollama:llama3"
+
 # File patterns to review (comma-separated globs)
 # Default: * (all files)
 FILE_PATTERNS="*.ts,*.tsx,*.js,*.jsx"
@@ -45,7 +50,7 @@ TIMEOUT="300"
 
 | Option             | Required | Default     | Description                              |
 | ------------------ | -------- | ----------- | ---------------------------------------- |
-| `PROVIDER`         | ✅ Yes   | -           | AI provider to use                       |
+| `PROVIDER`         | ✅ Yes   | -           | AI provider to use (comma-separated for fallback chain) |
 | `FILE_PATTERNS`    | No       | `*`         | Comma-separated file patterns to include |
 | `EXCLUDE_PATTERNS` | No       | -           | Comma-separated file patterns to exclude |
 | `RULES_FILE`       | No       | `AGENTS.md` | Path to your coding standards file       |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -28,6 +28,49 @@ Use whichever AI CLI you have installed:
 
 ---
 
+## Fallback Chain
+
+GGA supports a comma-separated fallback chain for providers. When the first provider fails with a transient error (timeout, rate-limit, network issue), GGA automatically tries the next provider in the list.
+
+```bash
+# Try Claude first, fall back to Gemini, then Ollama
+PROVIDER="claude,gemini,ollama:llama3"
+
+# Each entry can include per-provider :model syntax
+PROVIDER="claude,gemini,codex,ollama:codellama"
+```
+
+### How It Works
+
+1. **Sequential execution**: Providers are tried in order — never in parallel
+2. **Transient failure**: Timeout (exit 124), rate-limit (HTTP 429), server errors (HTTP 500/502/503), connection issues, or CLI not found (exit 126/127) → advance to next provider
+3. **Config error**: Missing API key, authentication failure (HTTP 401/403), invalid model → abort immediately, do NOT fall back
+4. **Success**: First provider to return exit 0 wins — remaining providers are skipped
+
+### Error Classification
+
+| Error Type | Examples | Behavior |
+|------------|----------|----------|
+| **TRANSIENT** | Timeout, HTTP 429/500/502/503, connection reset, exit 124/126/127 | Advance to next provider |
+| **CONFIG** | Missing API key, HTTP 401/403, invalid model, unknown provider | Abort immediately |
+
+### Examples
+
+```bash
+# Reliable CI/CD pipeline: try cloud, fall back to local
+PROVIDER="claude,gemini,ollama:llama3"
+
+# Cost optimization: try cheap first, escalate
+PROVIDER="ollama:llama3,claude"
+
+# Single provider (unchanged behavior, zero regression)
+PROVIDER="claude"
+```
+
+> **Note**: Fallback adds latency on failure — each transient attempt consumes the full timeout window. This is a deliberate tradeoff: reliability > speed for unattended CI/CD pipelines.
+
+---
+
 ## Provider Examples
 
 ```bash
@@ -99,6 +142,12 @@ PROVIDER="minimax:MiniMax-M3"
 # Antigravity / VS Code users: use any provider CLI from your integrated terminal
 # Antigravity comes with Gemini built-in — just set:
 PROVIDER="gemini"
+
+# Fallback chain: try Claude, fall back to Gemini, then Ollama
+PROVIDER="claude,gemini,ollama:llama3"
+
+# Fallback with per-provider models
+PROVIDER="claude,gemini,codex,ollama:codellama"
 ```
 
 ---

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -25,6 +25,9 @@ NC='\033[0m'
 # Provider Validation
 # ============================================================================
 
+# Returns 0 when the provider is usable, 127 when a dependency (CLI/tool) is
+# missing (TRANSIENT — fallback chain should advance), 1 on configuration
+# errors (CONFIG — chain should abort).
 validate_provider() {
   local provider="$1"
   local base_provider="${provider%%:*}"
@@ -37,7 +40,7 @@ validate_provider() {
         echo "Install Claude Code CLI:"
         echo "  https://claude.ai/code"
         echo ""
-        return 1
+        return 127
       fi
       ;;
     gemini)
@@ -49,7 +52,7 @@ validate_provider() {
         echo "  # or"
         echo "  brew install gemini"
         echo ""
-        return 1
+        return 127
       fi
       ;;
     codex)
@@ -61,7 +64,7 @@ validate_provider() {
         echo "  # or"
         echo "  brew install --cask codex"
         echo ""
-        return 1
+        return 127
       fi
       ;;
     opencode)
@@ -71,7 +74,7 @@ validate_provider() {
         echo "Install OpenCode CLI:"
         echo "  https://opencode.ai"
         echo ""
-        return 1
+        return 127
       fi
       ;;
     cursor)
@@ -81,7 +84,7 @@ validate_provider() {
         echo "Install Cursor Agent CLI:"
         echo "  curl https://cursor.com/install -fsS | bash"
         echo ""
-        return 1
+        return 127
       fi
       ;;
     kilo)
@@ -91,7 +94,7 @@ validate_provider() {
         echo "Install Kilo CLI:"
         echo "  npm install -g @kilocode/cli"
         echo ""
-        return 1
+        return 127
       fi
       ;;
     kiro)
@@ -101,7 +104,7 @@ validate_provider() {
         echo "Install Kiro CLI:"
         echo "  https://kiro.dev/downloads/"
         echo ""
-        return 1
+        return 127
       fi
       local model="${provider#*:}"
       if [[ "$model" != "$provider" && -n "$model" ]]; then
@@ -121,7 +124,7 @@ validate_provider() {
         echo "  # or"
         echo "  brew install ollama"
         echo ""
-        return 1
+        return 127
       fi
       # Check if model is specified
       local model="${provider#*:}"
@@ -145,7 +148,7 @@ validate_provider() {
         echo "  # Ubuntu/Debian: sudo apt-get install curl"
         echo "  # macOS: brew install curl"
         echo ""
-        return 1
+        return 127
       fi
       ;;
     github)
@@ -160,7 +163,7 @@ validate_provider() {
         echo "Then authenticate:"
         echo "  gh auth login"
         echo ""
-        return 1
+        return 127
       fi
       # GitHub Models requires curl for API calls
       if ! command -v curl &> /dev/null; then
@@ -171,7 +174,7 @@ validate_provider() {
         echo "  # Ubuntu/Debian: sudo apt-get install curl"
         echo "  # macOS: brew install curl"
         echo ""
-        return 1
+        return 127
       fi
       # Model is required for GitHub Models
       local model="${provider#*:}"
@@ -209,14 +212,14 @@ validate_provider() {
         echo "  # Ubuntu/Debian: sudo apt-get install curl"
         echo "  # macOS: brew install curl"
         echo ""
-        return 1
+        return 127
       fi
       if ! command -v python3 &> /dev/null; then
         echo -e "${RED}❌ python3 not found${NC}"
         echo ""
         echo "MiniMax response parsing requires python3."
         echo ""
-        return 1
+        return 127
       fi
       ;;
     *)
@@ -332,8 +335,15 @@ execute_with_fallback() {
   for (( i=0; i<chain_len; i++ )); do
     provider="${_chain[$i]}"
 
-    # Validate before executing
-    if ! validate_provider "$provider"; then
+    # Validate before executing. A missing dependency (exit 127) is TRANSIENT
+    # and advances the chain; a configuration error (exit 1) aborts.
+    validate_provider "$provider"
+    local validate_exit=$?
+    if [[ $validate_exit -ne 0 ]]; then
+      if [[ $validate_exit -eq 127 ]]; then
+        echo "↻ Provider '$provider' CLI not found, trying next..." >&2
+        continue
+      fi
       echo "↻ Provider '$provider' validation failed (CONFIG), aborting." >&2
       return 1
     fi

--- a/lib/providers.sh
+++ b/lib/providers.sh
@@ -243,6 +243,135 @@ validate_provider() {
 }
 
 # ============================================================================
+# Provider List Parsing (Phase 2 — Fallback Chain)
+# ============================================================================
+
+# Parse comma-separated PROVIDER into an ordered array.
+# Usage: parse_provider_list "$PROVIDER" array_name
+# Fills the caller array via nameref (bash 4.3+).
+# Trims whitespace, drops empty segments.
+parse_provider_list() {
+  local raw="$1"
+  local -n _out="$2"
+  local IFS=','
+  local segment
+
+  _out=()
+  for segment in $raw; do
+    # Trim leading/trailing whitespace via parameter expansion
+    segment="${segment#"${segment%%[![:space:]]*}"}"
+    segment="${segment%"${segment##*[![:space:]]}"}"
+    [[ -z "$segment" ]] && continue
+    _out+=("$segment")
+  done
+}
+
+# ============================================================================
+# Error Classification (Phase 2 — Fallback Chain)
+# ============================================================================
+
+# Classify a provider error as TRANSIENT or CONFIG.
+# Usage: classify_provider_error <exit_code> <combined_output>
+# Prints: TRANSIENT or CONFIG
+#
+# Classification rules (design §Interfaces / Contracts):
+#   CONFIG patterns (win on conflict):
+#     - empty API key, MINIMAX_API_KEY, API key, not authenticated
+#     - HTTP 401, 403
+#     - invalid model, requires a model, Unknown provider
+#   TRANSIENT (default):
+#     - exit 124, 126, 127
+#     - HTTP 429, 500, 502, 503
+#     - connection reset/refused, timeout, rate limit
+#     - unknown errors
+classify_provider_error() {
+  local code="$1"
+  local output="$2"
+
+  # CONFIG patterns — checked first so they win on conflict
+  if [[ "$output" =~ (API\ key|MINIMAX_API_KEY|not\ authenticated|Unknown\ provider|requires\ a\ model|Invalid.*model|401|403) ]]; then
+    echo "CONFIG"
+    return
+  fi
+
+  # TRANSIENT by exit code
+  case "$code" in
+    124|126|127)
+      echo "TRANSIENT"
+      return
+      ;;
+  esac
+
+  # TRANSIENT by output patterns
+  if [[ "$output" =~ (429|500|502|503|connection\ (reset|refused)|timed\ out|timeout|rate.?limit|Failed\ to\ connect) ]]; then
+    echo "TRANSIENT"
+    return
+  fi
+
+  # Unknown → TRANSIENT (conservative default)
+  echo "TRANSIENT"
+}
+
+# ============================================================================
+# Fallback Dispatch Wrapper (Phase 2 — Fallback Chain)
+# ============================================================================
+
+# Execute providers in order, advancing on TRANSIENT, aborting on CONFIG.
+# Usage: execute_with_fallback <prompt> <timeout> <chain_array_name>
+# Returns: 0 on success; last exit code on exhaustion or CONFIG abort.
+execute_with_fallback() {
+  local prompt="$1"
+  local timeout="$2"
+  local -n _chain="$3"
+  local chain_len="${#_chain[@]}"
+  local last_exit=1
+  local last_output=""
+  local provider
+  local i
+
+  for (( i=0; i<chain_len; i++ )); do
+    provider="${_chain[$i]}"
+
+    # Validate before executing
+    if ! validate_provider "$provider"; then
+      echo "↻ Provider '$provider' validation failed (CONFIG), aborting." >&2
+      return 1
+    fi
+
+    # Execute with timeout
+    last_output=$(execute_provider_with_timeout "$provider" "$prompt" "$timeout")
+    last_exit=$?
+
+    # Success → return immediately
+    if [[ $last_exit -eq 0 ]]; then
+      echo "$last_output"
+      return 0
+    fi
+
+    # Classify the failure
+    local error_class
+    error_class=$(classify_provider_error "$last_exit" "$last_output")
+
+    if [[ "$error_class" == "CONFIG" ]]; then
+      echo "↻ Provider '$provider' config error, aborting." >&2
+      echo "$last_output"
+      return 1
+    fi
+
+    # TRANSIENT → log and try next
+    local next_provider=""
+    if [[ $(( i + 1 )) -lt $chain_len ]]; then
+      next_provider="${_chain[$(( i + 1 ))]}"
+    fi
+    echo "↻ Provider '$provider' transient (exit $last_exit), trying '${next_provider:-none}'..." >&2
+  done
+
+  # All providers exhausted
+  echo "$last_output"
+  return "${last_exit:-1}"
+}
+
+# ============================================================================
 # Provider Execution
 # ============================================================================
 

--- a/spec/unit/providers_spec.sh
+++ b/spec/unit/providers_spec.sh
@@ -932,6 +932,50 @@ EOF
       The stderr should not include "mock-validate: gemini"
     End
 
+    It 'advances when provider CLI is missing (validate returns 127)'
+      declare -a GGA_CHAIN=(claude gemini)
+      validate_provider() {
+        echo "mock-validate: $1" >&2
+        case "$1" in
+          claude) return 127 ;;
+          gemini) return 0 ;;
+        esac
+      }
+      execute_provider_with_timeout() {
+        echo "mock-execute: $1" >&2
+        echo "STATUS: PASSED from gemini"
+        return 0
+      }
+
+      When call execute_with_fallback "prompt" 300 GGA_CHAIN
+      The output should eq "STATUS: PASSED from gemini"
+      The status should be success
+      The stderr should include "mock-validate: claude"
+      The stderr should include "CLI not found"
+      The stderr should include "mock-execute: gemini"
+      The stderr should not include "mock-execute: claude"
+    End
+
+    It 'aborts on validation CONFIG failure without executing or advancing'
+      declare -a GGA_CHAIN=(claude gemini)
+      validate_provider() {
+        echo "mock-validate: $1" >&2
+        return 1
+      }
+      execute_provider_with_timeout() {
+        echo "mock-execute: $1" >&2
+        echo "STATUS: PASSED"
+        return 0
+      }
+
+      When call execute_with_fallback "prompt" 300 GGA_CHAIN
+      The status should be failure
+      The stderr should include "mock-validate: claude"
+      The stderr should include "CONFIG"
+      The stderr should not include "mock-execute: claude"
+      The stderr should not include "mock-execute: gemini"
+    End
+
     It 'handles single-provider chain (passthrough)'
       declare -a GGA_CHAIN=(claude)
 

--- a/spec/unit/providers_spec.sh
+++ b/spec/unit/providers_spec.sh
@@ -675,39 +675,38 @@ EOF
   # ===========================================================================
 
   Describe 'parse_provider_list()'
+    # parse_provider_list writes into an array passed by nameref; it does NOT
+    # print to stdout. Assert the resulting array, not The output.
+
     It 'splits comma-separated list into ordered array'
       parse_provider_list "claude,gemini,ollama:llama3" _chain
-      The output should include "claude"
-      The output should include "gemini"
-      The output should include "ollama:llama3"
+      The value "${_chain[*]}" should eq "claude gemini ollama:llama3"
+      The value "${#_chain[@]}" should eq 3
     End
 
     It 'preserves per-provider :model suffix'
       parse_provider_list "ollama:llama3" _chain
-      The output should include "ollama:llama3"
+      The value "${_chain[*]}" should eq "ollama:llama3"
     End
 
     It 'ignores empty segments and trims whitespace'
       parse_provider_list "claude, ,gemini," _chain
-      The output should include "claude"
-      The output should include "gemini"
+      The value "${_chain[*]}" should eq "claude gemini"
     End
 
     It 'handles single provider (no comma)'
       parse_provider_list "claude" _chain
-      The output should include "claude"
+      The value "${_chain[*]}" should eq "claude"
     End
 
     It 'handles trailing comma gracefully'
       parse_provider_list "claude,gemini," _chain
-      The output should include "claude"
-      The output should include "gemini"
+      The value "${_chain[*]}" should eq "claude gemini"
     End
 
     It 'handles leading comma gracefully'
       parse_provider_list ",claude,gemini" _chain
-      The output should include "claude"
-      The output should include "gemini"
+      The value "${_chain[*]}" should eq "claude gemini"
     End
   End
 
@@ -840,151 +839,121 @@ EOF
   # ===========================================================================
 
   Describe 'execute_with_fallback()'
-    # Mock helpers for fallback tests
-    _fallback_validate_result=0
-    _fallback_execute_result=0
-    _fallback_execute_output=""
-    _fallback_classify_result="TRANSIENT"
-    _fallback_validate_call_count=0
-    _fallback_execute_call_count=0
-    _fallback_validate_call_order=""
-    _fallback_execute_call_order=""
-
-    reset_fallback_mocks() {
-      _fallback_validate_result=0
-      _fallback_execute_result=0
-      _fallback_execute_output=""
-      _fallback_classify_result="TRANSIENT"
-      _fallback_validate_call_count=0
-      _fallback_execute_call_count=0
-      _fallback_validate_call_order=""
-      _fallback_execute_call_order=""
-    }
+    # ShellSpec runs `When call` and every $(...) substitution in a subshell,
+    # so variable-based counters never survive. Mocks record calls on stderr
+    # (which IS captured) and decide behavior by provider name instead.
 
     validate_provider() {
-      _fallback_validate_call_count=$((_fallback_validate_call_count + 1))
-      _fallback_validate_call_order="${_fallback_validate_call_order} $1"
-      return "$_fallback_validate_result"
+      echo "mock-validate: $1" >&2
+      return 0
     }
 
+    # Default success mock; individual It blocks override with their own.
     execute_provider_with_timeout() {
-      _fallback_execute_call_count=$((_fallback_execute_call_count + 1))
-      _fallback_execute_call_order="${_fallback_execute_call_order} $1"
-      echo "$_fallback_execute_output"
-      return "$_fallback_execute_result"
+      echo "mock-execute: $1" >&2
+      echo "STATUS: PASSED"
+      return 0
     }
 
     classify_provider_error() {
-      echo "$_fallback_classify_result"
+      echo "TRANSIENT"
     }
 
     It 'stops on first success'
-      reset_fallback_mocks
       declare -a GGA_CHAIN=(claude gemini ollama:llama3)
-      _fallback_execute_result=0
-      _fallback_execute_output="STATUS: PASSED"
 
       When call execute_with_fallback "prompt" 300 GGA_CHAIN
       The output should eq "STATUS: PASSED"
       The status should be success
-      The variable _fallback_execute_call_count should eq 1
+      The stderr should include "mock-execute: claude"
+      The stderr should not include "mock-execute: gemini"
+      The stderr should not include "mock-execute: ollama:llama3"
     End
 
     It 'advances on TRANSIENT failure'
-      reset_fallback_mocks
       declare -a GGA_CHAIN=(claude gemini)
-      # First call returns TRANSIENT, second succeeds
-      _fallback_classify_result="TRANSIENT"
-      _fallback_execute_result=1
-      _fallback_execute_output=""
-      # We need a way to make the second call succeed
-      # Override execute_provider_with_timeout to use a counter
       execute_provider_with_timeout() {
-        _fallback_execute_call_count=$((_fallback_execute_call_count + 1))
-        _fallback_execute_call_order="${_fallback_execute_call_order} $1"
-        if [[ $_fallback_execute_call_count -eq 1 ]]; then
-          echo "timeout error"
-          return 124
-        else
-          echo "STATUS: PASSED from gemini"
-          return 0
-        fi
+        echo "mock-execute: $1" >&2
+        case "$1" in
+          claude) echo "timeout error"; return 124 ;;
+          gemini) echo "STATUS: PASSED from gemini"; return 0 ;;
+        esac
       }
 
       When call execute_with_fallback "prompt" 300 GGA_CHAIN
       The output should eq "STATUS: PASSED from gemini"
       The status should be success
-      The variable _fallback_execute_call_count should eq 2
+      The stderr should include "mock-execute: claude"
+      The stderr should include "mock-execute: gemini"
+      The stderr should include "trying"
     End
 
     It 'returns failure when all providers TRANSIENT-fail'
-      reset_fallback_mocks
       declare -a GGA_CHAIN=(claude gemini)
-      _fallback_classify_result="TRANSIENT"
       execute_provider_with_timeout() {
-        _fallback_execute_call_count=$((_fallback_execute_call_count + 1))
-        _fallback_execute_call_order="${_fallback_execute_call_order} $1"
+        echo "mock-execute: $1" >&2
         echo "error from $1"
         return 124
       }
 
       When call execute_with_fallback "prompt" 300 GGA_CHAIN
       The status should be failure
-      The variable _fallback_execute_call_count should eq 2
+      The output should include "error from gemini"
+      The stderr should include "mock-execute: claude"
+      The stderr should include "mock-execute: gemini"
+      The stderr should include "trying 'none'"
     End
 
     It 'hard-aborts on CONFIG error without trying next'
-      reset_fallback_mocks
       declare -a GGA_CHAIN=(claude gemini)
-      _fallback_classify_result="CONFIG"
+      classify_provider_error() {
+        echo "CONFIG"
+      }
       execute_provider_with_timeout() {
-        _fallback_execute_call_count=$((_fallback_execute_call_count + 1))
+        echo "mock-execute: $1" >&2
         echo "HTTP 403 Forbidden"
         return 1
       }
 
       When call execute_with_fallback "prompt" 300 GGA_CHAIN
       The status should be failure
-      The variable _fallback_execute_call_count should eq 1
+      The output should include "HTTP 403 Forbidden"
+      The stderr should include "config error"
+      The stderr should not include "mock-execute: gemini"
     End
 
     It 'validates each provider before executing'
-      reset_fallback_mocks
       declare -a GGA_CHAIN=(claude gemini)
-      _fallback_execute_result=0
-      _fallback_execute_output="STATUS: PASSED"
 
       When call execute_with_fallback "prompt" 300 GGA_CHAIN
-      The variable _fallback_validate_call_count should eq 1
+      The status should be success
+      The output should eq "STATUS: PASSED"
+      The stderr should include "mock-validate: claude"
+      The stderr should not include "mock-validate: gemini"
     End
 
     It 'handles single-provider chain (passthrough)'
-      reset_fallback_mocks
       declare -a GGA_CHAIN=(claude)
-      _fallback_execute_result=0
-      _fallback_execute_output="STATUS: PASSED"
 
       When call execute_with_fallback "prompt" 300 GGA_CHAIN
       The output should eq "STATUS: PASSED"
       The status should be success
-      The variable _fallback_execute_call_count should eq 1
+      The stderr should include "mock-execute: claude"
     End
 
     It 'logs transient fallback message to stderr'
-      reset_fallback_mocks
       declare -a GGA_CHAIN=(claude gemini)
       execute_provider_with_timeout() {
-        _fallback_execute_call_count=$((_fallback_execute_call_count + 1))
-        if [[ $_fallback_execute_call_count -eq 1 ]]; then
-          echo "timeout"
-          return 124
-        else
-          echo "STATUS: PASSED"
-          return 0
-        fi
+        echo "mock-execute: $1" >&2
+        case "$1" in
+          claude) echo "timeout"; return 124 ;;
+          gemini) echo "STATUS: PASSED"; return 0 ;;
+        esac
       }
 
       When call execute_with_fallback "prompt" 300 GGA_CHAIN
+      The status should be success
+      The output should eq "STATUS: PASSED"
       The stderr should include "claude"
       The stderr should include "trying"
     End

--- a/spec/unit/providers_spec.sh
+++ b/spec/unit/providers_spec.sh
@@ -669,4 +669,346 @@ EOF
       The output should eq "claude"
     End
   End
+
+  # ===========================================================================
+  # Phase 1: parse_provider_list (REQ-FC-001)
+  # ===========================================================================
+
+  Describe 'parse_provider_list()'
+    It 'splits comma-separated list into ordered array'
+      parse_provider_list "claude,gemini,ollama:llama3" _chain
+      The output should include "claude"
+      The output should include "gemini"
+      The output should include "ollama:llama3"
+    End
+
+    It 'preserves per-provider :model suffix'
+      parse_provider_list "ollama:llama3" _chain
+      The output should include "ollama:llama3"
+    End
+
+    It 'ignores empty segments and trims whitespace'
+      parse_provider_list "claude, ,gemini," _chain
+      The output should include "claude"
+      The output should include "gemini"
+    End
+
+    It 'handles single provider (no comma)'
+      parse_provider_list "claude" _chain
+      The output should include "claude"
+    End
+
+    It 'handles trailing comma gracefully'
+      parse_provider_list "claude,gemini," _chain
+      The output should include "claude"
+      The output should include "gemini"
+    End
+
+    It 'handles leading comma gracefully'
+      parse_provider_list ",claude,gemini" _chain
+      The output should include "claude"
+      The output should include "gemini"
+    End
+  End
+
+  # ===========================================================================
+  # Phase 1: classify_provider_error (REQ-FC-002 / REQ-FC-003)
+  # ===========================================================================
+
+  Describe 'classify_provider_error()'
+    # --- TRANSIENT cases (REQ-FC-002) ---
+
+    It 'classifies exit 124 (timeout) as TRANSIENT'
+      When call classify_provider_error 124 ""
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies exit 126 (command invoked not executable) as TRANSIENT'
+      When call classify_provider_error 126 ""
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies exit 127 (command not found) as TRANSIENT'
+      When call classify_provider_error 127 ""
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies HTTP 429 (rate limit) as TRANSIENT'
+      When call classify_provider_error 1 "HTTP 429 Too Many Requests"
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies HTTP 500 as TRANSIENT'
+      When call classify_provider_error 1 "HTTP 500 Internal Server Error"
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies HTTP 502 as TRANSIENT'
+      When call classify_provider_error 1 "HTTP 502 Bad Gateway"
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies HTTP 503 as TRANSIENT'
+      When call classify_provider_error 1 "HTTP 503 Service Unavailable"
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies connection reset as TRANSIENT'
+      When call classify_provider_error 1 "Connection reset by peer"
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies connection refused as TRANSIENT'
+      When call classify_provider_error 1 "Connection refused"
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies timeout in output as TRANSIENT'
+      When call classify_provider_error 1 "Request timed out"
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies rate limit text as TRANSIENT'
+      When call classify_provider_error 1 "rate limit exceeded"
+      The output should eq "TRANSIENT"
+    End
+
+    # --- CONFIG cases (REQ-FC-003) ---
+
+    It 'classifies missing API key (empty env) as CONFIG'
+      When call classify_provider_error 1 "API key not set"
+      The output should eq "CONFIG"
+    End
+
+    It 'classifies MINIMAX_API_KEY as CONFIG'
+      When call classify_provider_error 1 "MINIMAX_API_KEY not set"
+      The output should eq "CONFIG"
+    End
+
+    It 'classifies HTTP 401 as CONFIG'
+      When call classify_provider_error 1 "HTTP 401 Unauthorized"
+      The output should eq "CONFIG"
+    End
+
+    It 'classifies HTTP 403 as CONFIG'
+      When call classify_provider_error 1 "HTTP 403 Forbidden"
+      The output should eq "CONFIG"
+    End
+
+    It 'classifies invalid model as CONFIG'
+      When call classify_provider_error 1 "Invalid model name"
+      The output should eq "CONFIG"
+    End
+
+    It 'classifies not authenticated as CONFIG'
+      When call classify_provider_error 1 "not authenticated"
+      The output should eq "CONFIG"
+    End
+
+    It 'classifies unknown provider as CONFIG'
+      When call classify_provider_error 1 "Unknown provider"
+      The output should eq "CONFIG"
+    End
+
+    It 'classifies requires a model as CONFIG'
+      When call classify_provider_error 1 "requires a model"
+      The output should eq "CONFIG"
+    End
+
+    # --- Precedence: CONFIG wins if both match ---
+
+    It 'CONFIG pattern wins over TRANSIENT when both match'
+      When call classify_provider_error 1 "HTTP 401 Unauthorized and rate limit exceeded"
+      The output should eq "CONFIG"
+    End
+
+    # --- Unknown -> TRANSIENT ---
+
+    It 'classifies unknown errors as TRANSIENT'
+      When call classify_provider_error 1 "something completely unexpected"
+      The output should eq "TRANSIENT"
+    End
+
+    It 'classifies zero exit with unknown output as TRANSIENT'
+      When call classify_provider_error 0 "success but we check output"
+      The output should eq "TRANSIENT"
+    End
+  End
+
+  # ===========================================================================
+  # Phase 2: execute_with_fallback (REQ-FC-004 / REQ-FC-005 / REQ-PD-001)
+  # ===========================================================================
+
+  Describe 'execute_with_fallback()'
+    # Mock helpers for fallback tests
+    _fallback_validate_result=0
+    _fallback_execute_result=0
+    _fallback_execute_output=""
+    _fallback_classify_result="TRANSIENT"
+    _fallback_validate_call_count=0
+    _fallback_execute_call_count=0
+    _fallback_validate_call_order=""
+    _fallback_execute_call_order=""
+
+    reset_fallback_mocks() {
+      _fallback_validate_result=0
+      _fallback_execute_result=0
+      _fallback_execute_output=""
+      _fallback_classify_result="TRANSIENT"
+      _fallback_validate_call_count=0
+      _fallback_execute_call_count=0
+      _fallback_validate_call_order=""
+      _fallback_execute_call_order=""
+    }
+
+    validate_provider() {
+      _fallback_validate_call_count=$((_fallback_validate_call_count + 1))
+      _fallback_validate_call_order="${_fallback_validate_call_order} $1"
+      return "$_fallback_validate_result"
+    }
+
+    execute_provider_with_timeout() {
+      _fallback_execute_call_count=$((_fallback_execute_call_count + 1))
+      _fallback_execute_call_order="${_fallback_execute_call_order} $1"
+      echo "$_fallback_execute_output"
+      return "$_fallback_execute_result"
+    }
+
+    classify_provider_error() {
+      echo "$_fallback_classify_result"
+    }
+
+    It 'stops on first success'
+      reset_fallback_mocks
+      declare -a GGA_CHAIN=(claude gemini ollama:llama3)
+      _fallback_execute_result=0
+      _fallback_execute_output="STATUS: PASSED"
+
+      When call execute_with_fallback "prompt" 300 GGA_CHAIN
+      The output should eq "STATUS: PASSED"
+      The status should be success
+      The variable _fallback_execute_call_count should eq 1
+    End
+
+    It 'advances on TRANSIENT failure'
+      reset_fallback_mocks
+      declare -a GGA_CHAIN=(claude gemini)
+      # First call returns TRANSIENT, second succeeds
+      _fallback_classify_result="TRANSIENT"
+      _fallback_execute_result=1
+      _fallback_execute_output=""
+      # We need a way to make the second call succeed
+      # Override execute_provider_with_timeout to use a counter
+      execute_provider_with_timeout() {
+        _fallback_execute_call_count=$((_fallback_execute_call_count + 1))
+        _fallback_execute_call_order="${_fallback_execute_call_order} $1"
+        if [[ $_fallback_execute_call_count -eq 1 ]]; then
+          echo "timeout error"
+          return 124
+        else
+          echo "STATUS: PASSED from gemini"
+          return 0
+        fi
+      }
+
+      When call execute_with_fallback "prompt" 300 GGA_CHAIN
+      The output should eq "STATUS: PASSED from gemini"
+      The status should be success
+      The variable _fallback_execute_call_count should eq 2
+    End
+
+    It 'returns failure when all providers TRANSIENT-fail'
+      reset_fallback_mocks
+      declare -a GGA_CHAIN=(claude gemini)
+      _fallback_classify_result="TRANSIENT"
+      execute_provider_with_timeout() {
+        _fallback_execute_call_count=$((_fallback_execute_call_count + 1))
+        _fallback_execute_call_order="${_fallback_execute_call_order} $1"
+        echo "error from $1"
+        return 124
+      }
+
+      When call execute_with_fallback "prompt" 300 GGA_CHAIN
+      The status should be failure
+      The variable _fallback_execute_call_count should eq 2
+    End
+
+    It 'hard-aborts on CONFIG error without trying next'
+      reset_fallback_mocks
+      declare -a GGA_CHAIN=(claude gemini)
+      _fallback_classify_result="CONFIG"
+      execute_provider_with_timeout() {
+        _fallback_execute_call_count=$((_fallback_execute_call_count + 1))
+        echo "HTTP 403 Forbidden"
+        return 1
+      }
+
+      When call execute_with_fallback "prompt" 300 GGA_CHAIN
+      The status should be failure
+      The variable _fallback_execute_call_count should eq 1
+    End
+
+    It 'validates each provider before executing'
+      reset_fallback_mocks
+      declare -a GGA_CHAIN=(claude gemini)
+      _fallback_execute_result=0
+      _fallback_execute_output="STATUS: PASSED"
+
+      When call execute_with_fallback "prompt" 300 GGA_CHAIN
+      The variable _fallback_validate_call_count should eq 1
+    End
+
+    It 'handles single-provider chain (passthrough)'
+      reset_fallback_mocks
+      declare -a GGA_CHAIN=(claude)
+      _fallback_execute_result=0
+      _fallback_execute_output="STATUS: PASSED"
+
+      When call execute_with_fallback "prompt" 300 GGA_CHAIN
+      The output should eq "STATUS: PASSED"
+      The status should be success
+      The variable _fallback_execute_call_count should eq 1
+    End
+
+    It 'logs transient fallback message to stderr'
+      reset_fallback_mocks
+      declare -a GGA_CHAIN=(claude gemini)
+      execute_provider_with_timeout() {
+        _fallback_execute_call_count=$((_fallback_execute_call_count + 1))
+        if [[ $_fallback_execute_call_count -eq 1 ]]; then
+          echo "timeout"
+          return 124
+        else
+          echo "STATUS: PASSED"
+          return 0
+        fi
+      }
+
+      When call execute_with_fallback "prompt" 300 GGA_CHAIN
+      The stderr should include "claude"
+      The stderr should include "trying"
+    End
+  End
+
+  # ===========================================================================
+  # Phase 2 Task 2.3: ollama without model CONFIG hard-abort
+  # ===========================================================================
+
+  Describe 'validate_provider() - ollama without model'
+    It 'fails for ollama without model (CONFIG hard-abort)'
+      # validate_provider checks ollama CLI first, then model
+      # Without ollama CLI, it returns error for CLI not found
+      # With ollama mocked, it should fail on missing model
+      command() {
+        case "$2" in
+          ollama) return 0 ;;
+          *) return 1 ;;
+        esac
+      }
+
+      When call validate_provider "ollama"
+      The status should be failure
+      The output should include "requires a model"
+    End
+  End
 End


### PR DESCRIPTION
## Linked Issue

Closes #128

## PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature or enhancement
- [ ] `type:docs` — Documentation changes only
- [ ] `type:refactor` — Code refactor (no behavior change)
- [ ] `type:chore` — Maintenance (deps, CI, tooling)
- [ ] `type:breaking-change` — Breaking change (add `!` to commit type)

## Summary

Adds a provider fallback chain to the multi-provider runtime. When `PROVIDER` lists multiple providers (`claude,gemini,ollama:llama3`), GGA tries them strictly in order and only falls back on transient failures (timeout, HTTP 429/5xx, connection reset). Configuration errors (missing API key, invalid model, 401/403, `ollama` without a model) abort hard with a clear message — never silently masked.

## Changes

| File | Change |
|------|--------|
| `lib/providers.sh` | Adds `parse_provider_list()`, `classify_provider_error()`, `execute_with_fallback()` |
| `bin/gga` | Wires the comma-separated `PROVIDER` branch into `cmd_run`; help text |
| `spec/unit/providers_spec.sh` | New shellspec coverage for parsing, error classification, fallback/abort behavior, and logging |
| `docs/configuration.md` | Documents comma-separated `PROVIDER` syntax with optional `:model` |
| `docs/providers.md` | Documents fallback semantics: transient vs. config errors, strict sequential order |

## Test Plan

- [ ] `make lint` (ShellCheck) passes locally — *tool unavailable in this environment; runs in CI*
- [ ] `make test` passes locally (all unit tests) — *shellspec unavailable in this environment; runs in CI*
- [ ] `shellspec spec/unit` passes — *runs in CI*
- [ ] `shellspec spec/integration/commands_spec.sh` passes — *runs in CI*
- [x] Manual testing: `bash -n` syntax check passes on `bin/gga` and `lib/providers.sh`; single-provider path unchanged (zero-regression), fallback logic covered by new unit tests

## Automated Checks

The following checks run automatically on every PR:

| Check | Validates |
|-------|-----------|
| Check Issue Reference | PR body contains `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | Linked issue was approved by a maintainer |
| Check PR Has `type:*` Label | PR has exactly one `type:*` label |
| Lint | ShellCheck passes on `bin/gga` and `lib/*.sh` |
| Unit Tests | `shellspec spec/unit` passes |
| Integration Tests | `shellspec spec/integration/commands_spec.sh` passes |

## Contributor Checklist

- [x] I have linked the issue above with `Closes #N`
- [ ] The linked issue has `status:approved` — *maintainer label required; contributor lacks permission*
- [x] I have added a `type:*` label to this PR
- [ ] `make lint` passes (ShellCheck) — *tool unavailable in this environment; runs in CI*
- [ ] `make test` passes (all unit tests) — *shellspec unavailable in this environment; runs in CI*
- [ ] Integration tests pass — *runs in CI*
- [x] New functions/commands have tests in `spec/`
- [x] I followed conventional commits (`feat:`, `fix:`, `docs:`, etc.)
- [x] I have NOT added "Co-Authored-By" or AI attribution to commits
- [ ] Breaking changes are documented and use `!` in the commit type (`feat!:`, `fix!:`)

## Notes for Reviewers

- Same pattern as PR #74: the linked issue #128 is still `status:needs-review`. The contributor lacks permission to add `status:approved`. Once a maintainer adds that label, the `Check Issue Has status:approved` check passes; this PR was opened early per contributor request so the implementation is visible for review immediately.
- The lint/unit/integration checks will run via CI (`ubuntu-latest`); local tooling (ShellCheck, ShellSpec) is unavailable on this Windows host.
- Fallback is strictly sequential and only on transient failures; CONFIG errors abort hard — see the semantics documented in `docs/providers.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comma-separated provider fallback chains for reviews.
  * Automatically tries the next provider after transient failures, such as timeouts, rate limits, or network errors.
  * Stops immediately for configuration and authentication errors.
  * Validates each provider in the fallback chain.
  * Missing provider tools are treated as fallback failures when applicable.

* **Documentation**
  * Updated configuration and provider guides with fallback syntax, behavior, examples, and latency considerations.

* **Tests**
  * Added coverage for parsing, error handling, validation, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->